### PR TITLE
generalizes flux

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.10"
+version = "0.4.11"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/gradedunitrange.jl
+++ b/src/gradedunitrange.jl
@@ -103,10 +103,7 @@ function sectors(g::AbstractGradedUnitRange)
   return sector.(eachblockaxis(g))
 end
 
-function flux(a::AbstractGradedUnitRange, I::Block{1})
-  sect = sector(a[I])
-  return isdual(a) ? dual(sect) : sect
-end
+flux(a::AbstractBlockedUnitRange, I::Block{1}) = flux(a[I])
 
 function map_sectors(f, g::GradedUnitRange)
   return GradedUnitRange(map_sectors.(f, eachblockaxis(g)), ungrade(g))

--- a/src/sectorunitrange.jl
+++ b/src/sectorunitrange.jl
@@ -100,6 +100,10 @@ function flip(sr::SectorUnitRange)
   return sectorrange(dual(sector(sr)), ungrade(sr), !isdual(sr))
 end
 
+function flux(sr::SectorUnitRange)
+  return isdual(sr) ? dual(sector(sr)) : sector(sr)
+end
+
 function map_sectors(f, sr::SectorUnitRange)
   return sectorrange(f(sector(sr)), ungrade(sr), isdual(sr))
 end

--- a/test/test_gradedarray.jl
+++ b/test/test_gradedarray.jl
@@ -8,7 +8,9 @@ using GradedArrays:
   GradedVector,
   GradedOneTo,
   GradedUnitRange,
+  UndefinedFlux,
   U1,
+  checkflux,
   dag,
   dual,
   gradedrange,
@@ -61,6 +63,49 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     @test !(a isa GradedArray)
     a = BlockSparseArray{elt}(undef, r, b0, r)
     @test !(a isa GradedArray)
+  end
+
+  @testset "flux" begin
+    @test flux(ones(2)) == UndefinedFlux()
+    @test flux(ones()) == UndefinedFlux()
+    @test isnothing(checkflux(ones(2), UndefinedFlux()))
+    @test isnothing(checkflux(ones(), UndefinedFlux()))
+
+    r0 = blockedrange([2, 2])
+    v0 = BlockSparseArray{elt}(undef, r0)
+    @test flux(r0) == UndefinedFlux()
+    @test flux(r0, Block(1)) == UndefinedFlux()
+    @test flux(r0[Block(1)]) == UndefinedFlux()
+    @test flux(v0) == UndefinedFlux()
+    v0[Block(1)] = ones(2)
+    @test flux(v0) == UndefinedFlux()
+    @test isnothing(checkflux(v0, UndefinedFlux()))
+
+    r = gradedrange([U1(1) => 2, U1(2) => 2])
+    rd = dual(r)
+    @test flux(r) == UndefinedFlux()
+    @test flux(r, Block(1)) == U1(1)
+    @test flux(r[Block(1)]) == U1(1)
+    @test flux(rd) == UndefinedFlux()
+    @test flux(rd, Block(1)) == U1(-1)
+    @test flux(rd[Block(1)]) == U1(-1)
+
+    v = BlockSparseArray{elt}(undef, r)
+    @test flux(v) == UndefinedFlux()
+    v[Block(1)] = ones(2)
+    @test flux(v) == U1(1)
+    @test isnothing(checkflux(v, U1(1)))
+
+    v = BlockSparseArray{elt}(undef, rd)
+    @test flux(v) == UndefinedFlux()
+    v[Block(1)] = ones(2)
+    @test flux(v) == U1(-1)
+
+    v[Block(2)] = ones(2)
+    @test_throws ArgumentError checkflux(v, UndefinedFlux())
+    @test_throws ArgumentError checkflux(v, U1(-1))
+    @test_throws ArgumentError checkflux(v, U1(-2))
+    @test_throws ArgumentError flux(v)
   end
 
   @testset "map" begin

--- a/test/test_gradedarray.jl
+++ b/test/test_gradedarray.jl
@@ -13,6 +13,7 @@ using GradedArrays:
   checkflux,
   dag,
   dual,
+  flux,
   gradedrange,
   isdual,
   sectorrange,


### PR DESCRIPTION
This PR generalizes `flux`, to be used on ranges and `AbstractArray`. It also defines `UndefinedFlux` and `checkflux` and add tests. 

Fix #28 