### PR TITLE
generalizes `TensorAlgebra.trivial_axis`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.12"
+version = "0.4.13"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/ext/GradedArraysTensorAlgebraExt/GradedArraysTensorAlgebraExt.jl
+++ b/ext/GradedArraysTensorAlgebraExt/GradedArraysTensorAlgebraExt.jl
@@ -4,8 +4,10 @@ using BlockArrays: blocks
 using BlockSparseArrays: BlockSparseArray, blockreshape
 using GradedArrays:
   AbstractGradedUnitRange,
+  AbstractSector,
   GradedArray,
   flip,
+  gradedrange,
   invblockperm,
   sectormergesortperm,
   sectorsortperm,
@@ -13,6 +15,7 @@ using GradedArrays:
   unmerged_tensor_product
 using TensorAlgebra:
   TensorAlgebra,
+  ⊗,
   AbstractBlockPermutation,
   BlockedTuple,
   FusionStyle,
@@ -23,8 +26,10 @@ struct SectorFusion <: FusionStyle end
 
 TensorAlgebra.FusionStyle(::Type{<:GradedArray}) = SectorFusion()
 
-# TBD consider heterogeneous sectors?
-TensorAlgebra.trivial_axis(t::Tuple{Vararg{AbstractGradedUnitRange}}) = trivial(first(t))
+TensorAlgebra.trivial_axis(t::Tuple{Vararg{AbstractGradedUnitRange}}) = ⊗(trivial.(t)...)
+function TensorAlgebra.trivial_axis(::Type{S}) where {S<:AbstractSector}
+  return gradedrange([trivial(S) => 1])
+end
 
 function matricize_axes(
   blocked_axes::BlockedTuple{2,<:Any,<:Tuple{Vararg{AbstractUnitRange}}}

--- a/ext/GradedArraysTensorAlgebraExt/GradedArraysTensorAlgebraExt.jl
+++ b/ext/GradedArraysTensorAlgebraExt/GradedArraysTensorAlgebraExt.jl
@@ -26,7 +26,12 @@ struct SectorFusion <: FusionStyle end
 
 TensorAlgebra.FusionStyle(::Type{<:GradedArray}) = SectorFusion()
 
+function TensorAlgebra.trivial_axis(t::Tuple{Vararg{G}}) where {G<:AbstractGradedUnitRange}
+  return trivial(first(t))
+end
+# heterogeneous sectors
 TensorAlgebra.trivial_axis(t::Tuple{Vararg{AbstractGradedUnitRange}}) = ⊗(trivial.(t)...)
+# trivial_axis from sector_type
 function TensorAlgebra.trivial_axis(::Type{S}) where {S<:AbstractSector}
   return gradedrange([trivial(S) => 1])
 end

--- a/src/sectorunitrange.jl
+++ b/src/sectorunitrange.jl
@@ -28,7 +28,8 @@ end
 
 # sectorrange(SU2(1), 1)
 function sectorrange(s, m::Integer, b::Bool=false)
-  return sectorrange(s, Base.oneto(m * length(s)), b)
+  s1 = to_sector(s)  # convert now to get correct length of e.g. (;S=SU2(1))
+  return sectorrange(s1, Base.oneto(m * length(s1)), b)
 end
 
 # sectorrange(SU2(1) => 1)

--- a/test/test_symmetrysectors_sector_product.jl
+++ b/test/test_symmetrysectors_sector_product.jl
@@ -10,6 +10,7 @@ using GradedArrays:
   gradedrange,
   quantum_dimension,
   sector_type,
+  sectorrange,
   space_isequal,
   trivial
 using TensorProducts: ⊗
@@ -207,6 +208,13 @@ end
 
     g = gradedrange([(Nf=U1(0),) => 2, (Nf=U1(1),) => 3])
     @test sector_type(g) <: SectorProduct
+    sr = sectorrange((; S=SU2(1//2)) => 1)
+    @test length(sr) == 2
+    @test space_isequal(sr, sectorrange(SectorProduct(; S=SU2(1//2)), 1))
+    @test space_isequal(sr, sectorrange(SectorProduct(; S=SU2(1//2)), 1:2))
+    g = gradedrange([(; S=SU2(1//2)) => 1])
+    @test length(g) == 2
+    @test space_isequal(g, gradedrange([SectorProduct(; S=SU2(1//2)) => 1]))
 
     @test (A=U1(1),) × ((B=SU2(2),) × (C=U1(1),)) isa
       typeof((A=U1(1),) × (B=SU2(2),) × (C=U1(1),))

--- a/test/test_tensoralgebraext.jl
+++ b/test/test_tensoralgebraext.jl
@@ -2,7 +2,7 @@ using BlockArrays: Block, blocksize
 using BlockSparseArrays: BlockSparseArray
 using GradedArrays: GradedArray, GradedMatrix, U1, dual, flip, gradedrange, space_isequal
 using Random: randn!
-using TensorAlgebra: contract, matricize, unmatricize
+using TensorAlgebra: contract, matricize, trivial_axis, unmatricize
 using Test: @test, @testset
 
 function randn_blockdiagonal(elt::Type, axes::Tuple)
@@ -13,6 +13,15 @@ function randn_blockdiagonal(elt::Type, axes::Tuple)
     a[b] = randn!(a[b])
   end
   return a
+end
+
+@testset "trivial_axis" begin
+  gN = gradedrange([(; N=U1(1)) => 1])
+  gS = gradedrange([(; S=SU2(1//2)) => 1])
+  gNS = gradedrange([(; N=U1(0), S=SU2(0)) => 1])
+
+  @test space_isequal(trivial_axis(sector_type(gN)), gradedrange([(; N=U1(0)) => 1]))
+  @test space_isequal(trivial_axis((gN, gS)), gNS)
 end
 
 const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})

--- a/test/test_tensoralgebraext.jl
+++ b/test/test_tensoralgebraext.jl
@@ -1,6 +1,7 @@
 using BlockArrays: Block, blocksize
 using BlockSparseArrays: BlockSparseArray
-using GradedArrays: GradedArray, GradedMatrix, U1, dual, flip, gradedrange, space_isequal
+using GradedArrays:
+  GradedArray, GradedMatrix, SU2, U1, dual, flip, gradedrange, space_isequal
 using Random: randn!
 using TensorAlgebra: contract, matricize, trivial_axis, unmatricize
 using Test: @test, @testset

--- a/test/test_tensoralgebraext.jl
+++ b/test/test_tensoralgebraext.jl
@@ -19,6 +19,7 @@ end
   g1 = gradedrange([U1(1) => 1, U1(2) => 1])
   g2 = gradedrange([U1(-1) => 2, U1(2) => 1])
   @test space_isequal(trivial_axis((g1, g2)), gradedrange([U1(0) => 1]))
+  @test space_isequal(trivial_axis(sector_type(g1)), gradedrange([U1(0) => 1]))
 
   gN = gradedrange([(; N=U1(1)) => 1])
   gS = gradedrange([(; S=SU2(1//2)) => 1])

--- a/test/test_tensoralgebraext.jl
+++ b/test/test_tensoralgebraext.jl
@@ -1,7 +1,7 @@
 using BlockArrays: Block, blocksize
 using BlockSparseArrays: BlockSparseArray
 using GradedArrays:
-  GradedArray, GradedMatrix, SU2, U1, dual, flip, gradedrange, space_isequal
+  GradedArray, GradedMatrix, SU2, U1, dual, flip, gradedrange, sector_type, space_isequal
 using Random: randn!
 using TensorAlgebra: contract, matricize, trivial_axis, unmatricize
 using Test: @test, @testset

--- a/test/test_tensoralgebraext.jl
+++ b/test/test_tensoralgebraext.jl
@@ -16,10 +16,13 @@ function randn_blockdiagonal(elt::Type, axes::Tuple)
 end
 
 @testset "trivial_axis" begin
+  g1 = gradedrange([U1(1) => 1, U1(2) => 1])
+  g2 = gradedrange([U1(-1) => 2, U1(2) => 1])
+  @test space_isequal(trivial_axis((g1, g2)), gradedrange([U1(0) => 1]))
+
   gN = gradedrange([(; N=U1(1)) => 1])
   gS = gradedrange([(; S=SU2(1//2)) => 1])
   gNS = gradedrange([(; N=U1(0), S=SU2(0)) => 1])
-
   @test space_isequal(trivial_axis(sector_type(gN)), gradedrange([(; N=U1(0)) => 1]))
   @test space_isequal(trivial_axis((gN, gS)), gNS)
 end


### PR DESCRIPTION
This PR generalizes `TensorAlgebra.trivial_axis` for `AbstractSector`.
- now deals with heterogeneous `SectorProduct` and returns "largest" trivial axis
- also allows `trivial_axis(::AbstractSector)`, when only type information is available (to be used in `FusionTensors)`

It also fixes a bug where `sectorrange((;S=SU2(1//2)) => 1)` returned a length 1 axis.