### PR TITLE
fix non-abelian show

### DIFF
--- a/src/gradedunitrange.jl
+++ b/src/gradedunitrange.jl
@@ -180,7 +180,7 @@ function Base.show(io::IO, ::MIME"text/plain", g::AbstractGradedUnitRange)
 end
 
 function Base.show(io::IO, g::AbstractGradedUnitRange)
-  v = sectors(g) .=> blocklengths(g)
+  v = sectors(g) .=> sector_multiplicities(g)
   s = isdual(g) ? " dual " : ""
   return print(io, nameof(typeof(g)), s, '[', join(repr.(v), ", "), ']')
 end

--- a/test/test_gradedunitrange.jl
+++ b/test/test_gradedunitrange.jl
@@ -284,8 +284,9 @@ end
   @test space_isequal(dual(g), gradedrange([SU((0, 0)) => 2, SU((1, 0)) => 2]; isdual=true))
   @test !space_isequal(dual(g), g)
   @test space_isequal(flip(g), gradedrange([SU((0, 0)) => 2, SU((1, 1)) => 2]; isdual=true))
-  @test isnothing(show(devnull, MIME("text/plain"), g))
-  @test isnothing(show(devnull, g))
+  @test sprint(show, "text/plain", g) ==
+    "GradedUnitRange{Int64, SectorUnitRange{Int64, SU{3, 2}, Base.OneTo{Int64}}, BlockedOneTo{Int64, Vector{Int64}}, Vector{Int64}}\nSectorUnitRange SU{3}((0, 0)) => 1:2\nSectorUnitRange SU{3}((1, 0)) => 3:8"
+  @test sprint(show, g) == "GradedUnitRange[SU{3}((0, 0)) => 2, SU{3}((1, 0)) => 2]"
 
   @test iterate(g) == (1, 1)
   for i in 1:7


### PR DESCRIPTION
This PR fixes `Base.show` for non-abelian axes.
```julia
julia> g = gradedrange([SU2(0) => 1, SU2(1) => 1])
julia> println(g)
GradedUnitRange[SU2(0) => 1, SU2(1) => 3]  # old version
GradedUnitRange[SU2(0) => 1, SU2(1) => 1]  # new version
```