### PR TITLE
`check_mul_axes` specialization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["ITensor developers <support@itensor.org> and contributors"]
 version = "0.4.19"
 
 [deps]
+ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 BlockSparseArrays = "2c9a651f-6452-4ace-a6ac-809f4280fbb4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -23,6 +24,7 @@ TensorAlgebra = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 GradedArraysTensorAlgebraExt = "TensorAlgebra"
 
 [compat]
+ArrayLayouts = "1.11.2"
 BlockArrays = "1.6"
 BlockSparseArrays = "0.8, 0.9.3"
 Compat = "4.16"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.19"
+version = "0.4.20"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -24,7 +24,7 @@ TensorAlgebra = "68bd88dc-f39d-4e12-b2ca-f046b68fcc6a"
 GradedArraysTensorAlgebraExt = "TensorAlgebra"
 
 [compat]
-ArrayLayouts = "1.11.2"
+ArrayLayouts = "1"
 BlockArrays = "1.6"
 BlockSparseArrays = "0.8, 0.9.3"
 Compat = "4.16"

--- a/src/gradedarray.jl
+++ b/src/gradedarray.jl
@@ -9,6 +9,7 @@ using BlockSparseArrays:
   sparsemortar
 using LinearAlgebra: Adjoint
 using TypeParameterAccessors: similartype, unwrap_array_type
+using ArrayLayouts: ArrayLayouts
 
 const GradedArray{T,N,A<:AbstractArray{T,N},Blocks<:AbstractArray{A,N},Axes<:Tuple{AbstractGradedUnitRange{<:Integer},Vararg{AbstractGradedUnitRange{<:Integer}}}} = BlockSparseArray{
   T,N,A,Blocks,Axes
@@ -235,4 +236,12 @@ function Base.showarg(io::IO, a::GradedArray, toplevel::Bool)
   !toplevel && print(io, "::")
   print(io, concretetype_to_string_truncated(typeof(a); param_truncation_length=40))
   return nothing
+end
+
+const AnyGradedMatrix{T} = Union{GradedMatrix{T},Adjoint{T,<:GradedMatrix{T}}}
+
+function ArrayLayouts._check_mul_axes(A::AnyGradedMatrix, B::AnyGradedMatrix)
+  axA = axes(A, 2)
+  axB = axes(B, 1)
+  return space_isequal(dual(axA), axB) || ArrayLayouts.throw_mul_axes_err(axA, axB)
 end

--- a/test/test_gradedarray.jl
+++ b/test/test_gradedarray.jl
@@ -22,7 +22,7 @@ using GradedArrays:
 using SparseArraysBase: storedlength
 using LinearAlgebra: adjoint
 using Random: randn!
-using Test: @test, @testset
+using Test: @test, @testset, @test_throws
 
 function randn_blockdiagonal(elt::Type, axes::Tuple)
   a = BlockSparseArray{elt}(undef, axes)
@@ -387,12 +387,10 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
     a2[Block(2, 1)] = randn(elt, size(@view(a2[Block(2, 1)])))
     @test Array(a1 * a2) ≈ Array(a1) * Array(a2)
     @test Array(a1' * a2') ≈ Array(a1') * Array(a2')
-
-    a2 = BlockSparseArray{elt}(undef, r, dual(r))
-    a2[Block(1, 2)] = randn(elt, size(@view(a2[Block(1, 2)])))
-    a2[Block(2, 1)] = randn(elt, size(@view(a2[Block(2, 1)])))
     @test Array(a1' * a2) ≈ Array(a1') * Array(a2)
     @test Array(a1 * a2') ≈ Array(a1) * Array(a2')
+
+    @test_throws DimensionMismatch a1 * permutedims(a2, (2, 1))
   end
   @testset "Construct from dense" begin
     r = gradedrange([U1(0) => 2, U1(1) => 3])


### PR DESCRIPTION
This PR fixes #61, since the actual issue isn't flux conservation, the multiplied matrices are just not compatible, and the multiplication should error before even computing the result.