### PR TITLE
Drop sector in mixed broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
-version = "0.4.21"
+version = "0.4.22"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/sectorunitrange.jl
+++ b/src/sectorunitrange.jl
@@ -164,5 +164,5 @@ end
 # where some have SectorOneTo axes and some have OneTo axes,
 # which can show up in BlockSparseArrays blockwise broadcasting.
 # See https://github.com/ITensor/GradedArrays.jl/pull/65.
-Base.Broadcast.axistype(r1::SectorOneTo, ::Base.OneTo) = r1
-Base.Broadcast.axistype(::Base.OneTo, r2::SectorOneTo) = r2
+Base.Broadcast.axistype(::SectorOneTo, r2::Base.OneTo) = r2
+Base.Broadcast.axistype(r1::Base.OneTo, ::SectorOneTo) = r1

--- a/test/test_sectorunitrange.jl
+++ b/test/test_sectorunitrange.jl
@@ -165,7 +165,8 @@ using TestExtras: @constinferred
   @test sr1[sr2] ≡ sr2
 
   sr = sectorrange(U1(1), 4)
+  r = Base.OneTo(4)
   @test Broadcast.axistype(sr, sr) ≡ sr
-  @test Broadcast.axistype(sr, Base.OneTo(4)) ≡ sr
-  @test Broadcast.axistype(Base.OneTo(4), sr) ≡ sr
+  @test Broadcast.axistype(sr, r) ≡ r
+  @test Broadcast.axistype(r, sr) ≡ r
 end


### PR DESCRIPTION
Followup to #66, where instead we drop the sectors in mixed broadcasting.