### PR TITLE
Followup cleanup from type redesign PR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/GradedArrays.jl
+++ b/src/GradedArrays.jl
@@ -5,7 +5,9 @@ module GradedArrays
 export TrivialSector, Z, Z2, U1, O2, SU2, Fib, Ising
 export SectorRange, SectorOneTo, GradedOneTo
 export AbstractSectorDelta, AbelianSectorDelta, SectorIdentity
-export AbstractSectorArray, AbelianSectorArray, AbelianSectorMatrix, SectorMatrix
+export AbstractSectorArray,
+    AbelianSectorArray, AbelianSectorVector, AbelianSectorMatrix,
+    SectorMatrix
 export AbstractGradedArray, AbstractGradedMatrix
 export AbelianGradedArray, AbelianGradedVector, AbelianGradedMatrix
 export FusedGradedMatrix
@@ -14,15 +16,14 @@ export gradedrange
 export dual, flip, gradedrange, isdual,
     data, dataaxes, dataaxes1, datalength, datalengths,
     sector, sectoraxes, sectoraxes1, sectorlength, sectorlengths,
-    sectorrange, sectors, sector_type
+    sectors, sectortype
 
 # imports
 # -------
 import FunctionImplementations as FI
 using BlockArrays: BlockArrays, AbstractBlockArray, AbstractBlockVector, Block,
     BlockIndexRange, BlockVector, blocklength, blocklengths, blocks, eachblockaxes1
-using BlockSparseArrays:
-    BlockSparseArrays, eachblockaxis, eachblockstoredindex, mortar_axis, view!
+using BlockSparseArrays: BlockSparseArrays, eachblockaxis, eachblockstoredindex, mortar_axis
 using KroneckerArrays: KroneckerArrays, kroneckerfactors, ×, ⊗
 using LinearAlgebra: LinearAlgebra, Adjoint, mul!
 using TensorAlgebra: TensorAlgebra, BlockedTuple, FusionStyle, matricize, matricize_axes,

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -69,28 +69,12 @@ BlockSparseArrays.blocktype(a::AbelianGradedArray) = BlockSparseArrays.blocktype
 # view: returns a AbelianSectorArray sharing data (errors for unstored blocks)
 function Base.view(a::AbelianGradedArray{T, N}, I::Vararg{Block{1}, N}) where {T, N}
     bk = ntuple(d -> Int(I[d]), Val(N))
-    haskey(a.blockdata, bk) || error("Block $bk is not stored. Use view! to create it.")
+    haskey(a.blockdata, bk) || error("Block $bk is not stored.")
     sects = ntuple(d -> sectors(axes(a, d))[bk[d]], Val(N))
     return AbelianSectorArray(sects, a.blockdata[bk])
 end
 function Base.view(a::AbelianGradedArray{T, N}, I::Block{N}) where {T, N}
     return view(a, Tuple(I)...)
-end
-
-# view!: get or create, then view
-function BlockSparseArrays.view!(
-        a::AbelianGradedArray{T, N}, I::Vararg{Block{1}, N}
-    ) where {T, N}
-    bk = ntuple(d -> Int(I[d]), Val(N))
-    if !haskey(a.blockdata, bk)
-        block_dims = ntuple(d -> blocklengths(axes(a, d))[bk[d]], Val(N))
-        a.blockdata[bk] = zeros(T, block_dims)
-    end
-    sects = ntuple(d -> sectors(axes(a, d))[bk[d]], Val(N))
-    return AbelianSectorArray(sects, a.blockdata[bk])
-end
-function BlockSparseArrays.view!(a::AbelianGradedArray{<:Any, N}, I::Block{N}) where {N}
-    return BlockSparseArrays.view!(a, Tuple(I)...)
 end
 
 # ---------------------------------------------------------------------------
@@ -119,8 +103,7 @@ end
 function Base.setindex!(
         b::AbelianBlocks{T, N}, value, I::Vararg{Int, N}
     ) where {T, N}
-    # Use view! to get-or-create, then copyto! (following BlockSparseArrays pattern)
-    dest = view!(b.parent, Block.(I)...)
+    dest = view(b.parent, Block.(I)...)
     copyto!(dest, value)
     return b
 end
@@ -129,16 +112,9 @@ end
 #  getindex / setindex! on AbelianGradedArray with Block — convenience wrappers
 # ---------------------------------------------------------------------------
 
-# getindex: returns a copy (unstored blocks return zeros)
+# getindex: returns a copy (errors for unstored blocks)
 function Base.getindex(a::AbelianGradedArray{T, N}, I::Vararg{Block{1}, N}) where {T, N}
-    bk = ntuple(d -> Int(I[d]), Val(N))
-    if haskey(a.blockdata, bk)
-        return copy(view(a, I...))
-    else
-        block_dims = ntuple(d -> blocklengths(axes(a, d))[bk[d]], Val(N))
-        sects = ntuple(d -> sectors(axes(a, d))[bk[d]], Val(N))
-        return AbelianSectorArray(sects, zeros(T, block_dims))
-    end
+    return copy(view(a, I...))
 end
 function Base.getindex(a::AbelianGradedArray{T, N}, I::Block{N}) where {T, N}
     return a[Tuple(I)...]
@@ -149,12 +125,12 @@ function Base.setindex!(a::AbelianGradedArray{<:Any, N}, value, I::Block{N}) whe
     return setindex!(a, value, Tuple(I)...)
 end
 
-# Primitive: get-or-create block view, then broadcast in.
+# Primitive: view existing block, then broadcast in.
 # Handles both AbelianSectorArray and raw data values.
 function Base.setindex!(
         a::AbelianGradedArray{<:Any, N}, value::AbstractArray{<:Any, N}, I::Vararg{Block{1}, N}
     ) where {N}
-    BlockSparseArrays.view!(a, I...) .= value
+    view(a, I...) .= value
     return a
 end
 
@@ -280,10 +256,10 @@ function Base.similar(a::AbelianGradedArray{T}) where {T}
 end
 
 # ---------------------------------------------------------------------------
-#  sector_type
+#  sectortype
 # ---------------------------------------------------------------------------
 
-sector_type(::Type{<:AbelianGradedArray{T, N, D, S}}) where {T, N, D, S} = S
+sectortype(::Type{<:AbelianGradedArray{T, N, D, S}}) where {T, N, D, S} = S
 
 # ---------------------------------------------------------------------------
 #  permutedims

--- a/src/abeliansectorarray.jl
+++ b/src/abeliansectorarray.jl
@@ -13,13 +13,20 @@ struct AbelianSectorArray{T, N, A <: AbstractArray{T, N}, S <: SectorRange} <:
 end
 
 # Constructors
+
+# Fully-parameterized undef constructor: accepts SectorOneTo axes.
+function AbelianSectorArray{T, N, A, S}(
+        ::UndefInitializer, axs::NTuple{N, SectorOneTo{S}}
+    ) where {T, N, A <: AbstractArray{T, N}, S <: SectorRange}
+    sects = sector.(axs)
+    return AbelianSectorArray{T, N, A, S}(sects, similar(A, data.(axs)))
+end
+
+# Convenience: infer A = Array{T,N} and S from axes.
 function AbelianSectorArray{T}(
-        ::UndefInitializer,
-        sectors::NTuple{N, S},
-        dims::NTuple{N, Int}
+        ::UndefInitializer, axs::NTuple{N, SectorOneTo{S}}
     ) where {T, N, S <: SectorRange}
-    data = Array{T, N}(undef, dims)
-    return AbelianSectorArray{T, N, Array{T, N}, S}(sectors, data)
+    return AbelianSectorArray{T, N, Array{T, N}, S}(undef, axs)
 end
 
 # Construct from AbelianSectorDelta (inverse of sector/data decomposition)
@@ -30,29 +37,27 @@ function AbelianSectorArray(
     return AbelianSectorArray(delta.sectors, data)
 end
 
+const AbelianSectorVector{T, A <: AbstractVector{T}, S <: SectorRange} =
+    AbelianSectorArray{T, 1, A, S}
 const AbelianSectorMatrix{T, A <: AbstractMatrix{T}, S <: SectorRange} =
     AbelianSectorArray{T, 2, A, S}
 
 # Accessors
-sectoraxes(sa::AbelianSectorArray) = sa.sectors
-function datalengths(sa::AbelianSectorArray)
-    return ntuple(
-        d -> div(size(data(sa), d), length(sectoraxes(sa, d))), Val(ndims(sa))
-    )
-end
 
 # Kronecker factor decomposition: AbelianSectorArray = sector ⊗ data
 sector(sa::AbelianSectorArray) = AbelianSectorDelta{eltype(sa)}(sa.sectors)
+sectoraxes(sa::AbelianSectorArray) = axes(sector(sa))
 dataaxes(sa::AbelianSectorArray) = axes(data(sa))
 
-sector_type(::Type{<:AbelianSectorArray{T, N, A, S}}) where {T, N, A, S} = S
+sectortype(::Type{<:AbelianSectorArray{T, N, A, S}}) where {T, N, A, S} = S
 datatype(::Type{AbelianSectorArray{T, N, A, S}}) where {T, N, A, S} = A
 
 # AbstractArray interface
 # -----------------------
 function Base.axes(sa::AbelianSectorArray)
-    mults = datalengths(sa)
-    return ntuple(d -> sectorrange(sectoraxes(sa, d), mults[d]), Val(ndims(sa)))
+    sa_axes = sectoraxes(sa)
+    da_axes = dataaxes(sa)
+    return ntuple(d -> SectorOneTo(sa_axes[d], length(da_axes[d])), Val(ndims(sa)))
 end
 
 Base.copy(A::AbelianSectorArray) = AbelianSectorArray(sector(A), copy(data(A)))
@@ -129,8 +134,8 @@ end
 # ========================  Other  ========================
 
 function KroneckerArrays.:(⊗)(
-        A::AbelianSectorDelta{<:Any, N},
+        s::AbelianSectorDelta{<:Any, N},
         data::AbstractArray{<:Any, N}
     ) where {N}
-    return AbelianSectorArray(A, data)
+    return AbelianSectorArray(s, data)
 end

--- a/src/abeliansectordelta.jl
+++ b/src/abeliansectordelta.jl
@@ -26,26 +26,11 @@ end
 
 Base.axes(A::AbelianSectorDelta) = A.sectors
 
-function Base.similar(
-        ::AbelianSectorDelta,
-        ::Type{T},
-        sranges::Tuple{SectorRange, Vararg{SectorRange}}
-    ) where {T}
-    return AbelianSectorDelta{T}(sranges)
-end
-
-function Base.similar(
-        ::Type{<:AbstractArray{T}},
-        sranges::Tuple{SectorRange, Vararg{SectorRange}}
-    ) where {T}
-    return AbelianSectorDelta{T}(sranges)
-end
-
 # ========================  Accessors  ========================
 
 isdual(x, d::Int) = isdual(axes(x, d))
 sectoraxes(x, d::Int) = sectoraxes(x)[d]
-sector_type(::Type{<:AbelianSectorDelta{T, N, S}}) where {T, N, S} = S
+sectortype(::Type{<:AbelianSectorDelta{T, N, S}}) where {T, N, S} = S
 
 # ========================  permutedims  ========================
 
@@ -102,7 +87,7 @@ function fermion_permutation_phase(
         perm::NTuple{N, Int}
     ) where {N}
     require_unique_fusion(x)
-    BS = TKS.BraidingStyle(sector_type(x))
+    BS = TKS.BraidingStyle(sectortype(x))
     BS isa TKS.Bosonic && return true
     @assert BS isa TKS.Fermionic "Only symmetric braiding is supported"
 
@@ -115,7 +100,7 @@ function fermion_contraction_phase(
         length_codomain::Int
     ) where {N}
     require_unique_fusion(x)
-    BS = TKS.BraidingStyle(sector_type(x))
+    BS = TKS.BraidingStyle(sectortype(x))
     BS isa TKS.Bosonic && return true
     @assert BS isa TKS.Fermionic "Only symmetric braiding is supported"
     length_codomain <= ndims(x) ||

--- a/src/abstractsectorarray.jl
+++ b/src/abstractsectorarray.jl
@@ -38,7 +38,7 @@ end
 # ========================  Shared utilities  ========================
 
 function require_unique_fusion(A)
-    return TKS.FusionStyle(sector_type(A)) === TKS.UniqueFusion() ||
+    return TKS.FusionStyle(sectortype(A)) === TKS.UniqueFusion() ||
         error("not implemented for non-abelian tensors")
 end
 

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -42,7 +42,7 @@ function BlockSparseArrays.blocktype(::Type{<:FusedGradedMatrix{T, D, S}}) where
     return SectorMatrix{T, D, S}
 end
 BlockSparseArrays.blocktype(m::FusedGradedMatrix) = BlockSparseArrays.blocktype(typeof(m))
-sector_type(::Type{<:FusedGradedMatrix{T, D, S}}) where {T, D, S} = S
+sectortype(::Type{<:FusedGradedMatrix{T, D, S}}) where {T, D, S} = S
 
 function Base.axes(m::FusedGradedMatrix)
     codomain = gradedrange(m.sectors .=> size.(m.blocks, 1))

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -85,7 +85,7 @@ function TensorAlgebra.matricize(
     biperm = trivialbiperm(ndims_codomain, Val(ndims(a)))
     ax_codomain, ax_domain = blocks(axes(a)[biperm])
     ax_codomain =
-        isempty(ax_codomain) ? trivial(sector_type(a)) : tensor_product(ax_codomain...)
+        isempty(ax_codomain) ? trivial(sectortype(a)) : tensor_product(ax_codomain...)
     return SectorIdentity{eltype(a)}(ax_codomain)
 end
 
@@ -96,7 +96,7 @@ function TensorAlgebra.matricize(
     ) where {K}
     asectors_reshaped = matricize(sector(a), Val(K))
 
-    T = TKS.sectorscalartype(sector_type(a))
+    T = TKS.sectorscalartype(sectortype(a))
     phase = prod(
         ntuple(K) do i
             return ifelse(isdual(a, i), twist(sectoraxes(a, i)), one(T))

--- a/src/gradedoneto.jl
+++ b/src/gradedoneto.jl
@@ -38,8 +38,8 @@ BlockArrays.blocklength(g::GradedOneTo) = length(g.nondual_sectors)
 BlockArrays.eachblockaxes1(g::GradedOneTo) = eachblockaxis(g)
 Base.length(g::GradedOneTo) = sum(blocklengths(g); init = 0)
 
-# sector_type, SymmetryStyle
-sector_type(::Type{GradedOneTo{S}}) where {S} = S
+# sectortype, SymmetryStyle
+sectortype(::Type{GradedOneTo{S}}) where {S} = S
 SymmetryStyle(::Type{<:GradedOneTo{S}}) where {S} = SymmetryStyle(S)
 
 # blocklengths: total length of each block (length(sector) * multiplicity)

--- a/src/sectoridentity.jl
+++ b/src/sectoridentity.jl
@@ -24,7 +24,7 @@ function Base.axes(A::SectorIdentity)
     return (A.sector, dual(A.sector))
 end
 
-sector_type(::Type{<:SectorIdentity{T, S}}) where {T, S} = S
+sectortype(::Type{<:SectorIdentity{T, S}}) where {T, S} = S
 
 function Base.permutedims(a::SectorIdentity, perm)
     perm == ntuple(identity, ndims(a)) && return a

--- a/src/sectormatrix.jl
+++ b/src/sectormatrix.jl
@@ -28,13 +28,13 @@ end
 sector(sm::SectorMatrix) = SectorIdentity{eltype(sm)}(sm.sector)
 dataaxes(sm::SectorMatrix) = axes(data(sm))
 
-sector_type(::Type{<:SectorMatrix{T, D, S}}) where {T, D, S} = S
+sectortype(::Type{<:SectorMatrix{T, D, S}}) where {T, D, S} = S
 datatype(::Type{SectorMatrix{T, D, S}}) where {T, D, S} = D
 
 function Base.axes(sm::SectorMatrix)
     return (
-        sectorrange(sm.sector, size(data(sm), 1)),
-        sectorrange(dual(sm.sector), size(data(sm), 2)),
+        SectorOneTo(sm.sector, size(data(sm), 1)),
+        SectorOneTo(dual(sm.sector), size(data(sm), 2)),
     )
 end
 
@@ -57,6 +57,6 @@ function Base.similar(sm::SectorMatrix, ::Type{T}) where {T}
     return SectorMatrix(sm.sector, similar(data(sm), T))
 end
 
-function KroneckerArrays.:(⊗)(A::SectorIdentity, data::AbstractMatrix)
-    return SectorMatrix(A.sector, data)
+function KroneckerArrays.:(⊗)(s::SectorIdentity, data::AbstractMatrix)
+    return SectorMatrix(s.sector, data)
 end

--- a/src/sectoroneto.jl
+++ b/src/sectoroneto.jl
@@ -44,8 +44,8 @@ Base.first(::SectorOneTo) = 1
 Base.last(r::SectorOneTo) = length(r)
 Base.length(r::SectorOneTo) = sectorlength(r) * datalength(r)
 
-# sector_type, SymmetryStyle
-sector_type(::Type{SectorOneTo{S}}) where {S} = S
+# sectortype, SymmetryStyle
+sectortype(::Type{SectorOneTo{S}}) where {S} = S
 SymmetryStyle(::Type{<:SectorOneTo{S}}) where {S} = SymmetryStyle(S)
 
 # dual, flip, flip_dual
@@ -61,23 +61,6 @@ end
 Base.:(==)(a::SectorOneTo, b::SectorOneTo) = isequal(a, b)
 function Base.hash(r::SectorOneTo, h::UInt)
     return hash(sector(r), hash(datalength(r), h))
-end
-
-# ========================  sectorrange constructors  ========================
-
-"""
-    sectorrange(sector, dim)
-    sectorrange(sector, range)
-
-Construct a [`SectorOneTo`](@ref) for the given sector and data length.
-"""
-sectorrange(s::SectorRange, dim::Integer) = SectorOneTo(s, Int(dim))
-sectorrange(s::SectorRange, range::AbstractUnitRange) = sectorrange(s, length(range))
-function sectorrange(
-        sector::NamedTuple{<:Any, <:Tuple{SectorRange, Vararg{SectorRange}}},
-        args...
-    )
-    return sectorrange(to_sector(sector), args...)
 end
 
 to_gradedrange(r::SectorOneTo) = gradedrange([sector(r) => datalength(r)])
@@ -100,7 +83,7 @@ end
 
 function tensor_product(::AbelianStyle, r1::SectorOneTo, r2::SectorOneTo)
     s = tensor_product(sector(flip_dual(r1)), sector(flip_dual(r2)))
-    return sectorrange(s, datalength(r1) * datalength(r2))
+    return SectorOneTo(s, datalength(r1) * datalength(r2))
 end
 
 function tensor_product(::NotAbelianStyle, r1::SectorOneTo, r2::SectorOneTo)

--- a/src/sectorrange.jl
+++ b/src/sectorrange.jl
@@ -17,9 +17,9 @@ SectorRange(label::TKS.Sector) = SectorRange(label, false)
 label(r::SectorRange) = r.label
 isdual(r::SectorRange) = r.isdual
 
-sector_type(x) = sector_type(typeof(x))
-sector_type(S::Type{<:SectorRange}) = S
-sector_type(T::Type) = throw(MethodError(sector_type, T))
+sectortype(x) = sectortype(typeof(x))
+sectortype(S::Type{<:SectorRange}) = S
+sectortype(T::Type) = throw(MethodError(sectortype, T))
 
 # ===================================  Base interface  =====================================
 
@@ -60,7 +60,7 @@ Base.axes(r::SectorRange) = (r,)
 
 trivial(x) = trivial(typeof(x))
 function trivial(axis_type::Type{<:AbstractUnitRange})
-    return gradedrange([trivial(sector_type(axis_type)) => 1])  # always returns nondual
+    return gradedrange([trivial(sectortype(axis_type)) => 1])  # always returns nondual
 end
 function trivial(type::Type)
     return error("`trivial` not defined for type $(type).")
@@ -128,7 +128,7 @@ function SymmetryStyle(::Type{T}) where {T <: SectorRange}
         return NotAbelianStyle()
     end
 end
-SymmetryStyle(G::Type{<:AbstractUnitRange}) = SymmetryStyle(sector_type(G))
+SymmetryStyle(G::Type{<:AbstractUnitRange}) = SymmetryStyle(sectortype(G))
 
 combine_styles(::AbelianStyle, ::AbelianStyle) = AbelianStyle()
 combine_styles(::SymmetryStyle, ::SymmetryStyle) = NotAbelianStyle()

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -171,7 +171,7 @@ function TensorAlgebra.permutedimsopadd!(
     for bI in eachblockstoredindex(x)
         b = Tuple(bI)
         b_dest = Block(ntuple(i -> b[perm[i]], N))
-        y_b = view!(y, Tuple(b_dest)...)
+        y_b = view(y, Tuple(b_dest)...)
         x_b = x[bI]
         TensorAlgebra.permutedimsopadd!(y_b, op, x_b, perm, α, true)
     end

--- a/test/test_abelianarray.jl
+++ b/test/test_abelianarray.jl
@@ -2,7 +2,7 @@ using BlockArrays: BlockArrays, Block, blocklength
 using BlockSparseArrays: eachblockstoredindex
 using GradedArrays: GradedArrays, AbelianGradedArray, AbelianSectorArray,
     AbstractGradedArray, FusedGradedMatrix, GradedOneTo, SU2, SectorRange, U1, data,
-    datalengths, dual, gradedrange, isdual, sector_type, sectoraxes, sectors
+    datalengths, dual, gradedrange, isdual, sectoraxes, sectors, sectortype
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @test_throws, @testset
 
@@ -57,12 +57,9 @@ using Test: @test, @test_throws, @testset
         @test sectoraxes(blk) == (U1(0)', U1(0))
     end
 
-    @testset "Block getindex for unstored block returns zeros" begin
+    @testset "Block getindex for unstored block errors" begin
         a = AbelianGradedArray{Float64}(undef, g1, g2)
-        blk = a[Block(2, 1)]
-        @test blk isa AbelianSectorArray
-        @test all(iszero, data(blk))
-        @test size(blk) == (3, 1)
+        @test_throws ErrorException a[Block(2, 1)]
     end
 
     @testset "Single Block{N} argument" begin
@@ -128,21 +125,22 @@ using Test: @test, @test_throws, @testset
         @test size(a3) == size(a)
     end
 
-    @testset "sector_type" begin
+    @testset "sectortype" begin
         a = AbelianGradedArray{Float64}(undef, g1, g2)
-        @test sector_type(typeof(a)) == U1
+        @test sectortype(typeof(a)) == U1
     end
 
-    @testset "Multiple block insertions" begin
+    @testset "Stored block insertions" begin
         a = AbelianGradedArray{Float64}(undef, g1, g2)
         a[Block(1, 1)] = ones(2, 1)
-        a[Block(1, 2)] = 2.0 * ones(2, 2)
-        a[Block(2, 1)] = 3.0 * ones(3, 1)
         a[Block(2, 2)] = 4.0 * ones(3, 2)
 
-        @test length(collect(eachblockstoredindex(a))) == 4
-        @test data(a[Block(1, 2)]) == 2.0 * ones(2, 2)
-        @test data(a[Block(2, 1)]) == 3.0 * ones(3, 1)
+        @test length(collect(eachblockstoredindex(a))) == 2
+        @test data(a[Block(1, 1)]) == ones(2, 1)
+        @test data(a[Block(2, 2)]) == 4.0 * ones(3, 2)
+
+        # Setting unstored (non-allowed) blocks errors
+        @test_throws ErrorException (a[Block(1, 2)] = 2.0 * ones(2, 2))
     end
 
     @testset "SU2 (non-abelian dimensions)" begin

--- a/test/test_exports.jl
+++ b/test/test_exports.jl
@@ -12,6 +12,7 @@ using Test: @test, @testset
         :AbelianSectorArray,
         :AbelianSectorDelta,
         :AbelianSectorMatrix,
+        :AbelianSectorVector,
         :FusedGradedMatrix,
         :Fib,
         :GradedArrays,
@@ -41,9 +42,8 @@ using Test: @test, @testset
         :sectoraxes1,
         :sectorlength,
         :sectorlengths,
-        :sectorrange,
         :sectors,
-        :sector_type,
+        :sectortype,
     ]
     @test issetequal(names(GradedArrays), exports)
 end

--- a/test/test_gradedoneto.jl
+++ b/test/test_gradedoneto.jl
@@ -1,6 +1,6 @@
 using BlockArrays: blocklength
 using GradedArrays: GradedArrays, GradedOneTo, SU2, SectorRange, U1, datalengths, dual,
-    flip, gradedrange, isdual, sector_type, sectors, tensor_product
+    flip, gradedrange, isdual, sectors, sectortype, tensor_product
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @test_throws, @testset
 
@@ -110,9 +110,9 @@ using Test: @test, @test_throws, @testset
         @test d[g2] == "value"
     end
 
-    @testset "sector_type" begin
-        @test sector_type(GradedOneTo{U1}) == U1
-        @test sector_type(GradedOneTo{SU2}) == SU2
+    @testset "sectortype" begin
+        @test sectortype(GradedOneTo{U1}) == U1
+        @test sectortype(GradedOneTo{SU2}) == SU2
     end
 
     @testset "show" begin

--- a/test/test_sectorarray.jl
+++ b/test/test_sectorarray.jl
@@ -1,6 +1,6 @@
 using GradedArrays: GradedArrays, AbelianSectorArray, AbelianSectorDelta,
-    AbelianSectorMatrix, SU2, SectorRange, U1, data, datalengths, dual, isdual, sector,
-    sector_type, sectoraxes
+    AbelianSectorMatrix, AbelianSectorVector, SU2, SectorOneTo, SectorRange, U1, data, dual,
+    isdual, sector, sectoraxes, sectortype
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @test_throws, @testset
 
@@ -19,11 +19,10 @@ using Test: @test, @test_throws, @testset
         @test sectoraxes(sa) == (U1(1), U1(-1)')
     end
 
-    @testset "Undef constructor" begin
+    @testset "Undef constructor (SectorOneTo)" begin
         sa = AbelianSectorArray{Float64}(
             undef,
-            (U1(0), U1(1)),
-            (3, 4)
+            (SectorOneTo(U1(0), 3), SectorOneTo(U1(1), 4))
         )
         @test size(sa) == (3, 4)
         @test eltype(sa) == Float64
@@ -59,24 +58,10 @@ using Test: @test, @test_throws, @testset
         @test axes(sd) == sectoraxes(sa)
     end
 
-    @testset "Derived accessors — datalengths (U1, dim=1)" begin
-        data = ones(3, 5)
-        sa = AbelianSectorArray((U1(1), U1(0)), data)
-        @test datalengths(sa) == (3, 5)
-    end
-
-    @testset "Derived accessors — datalengths (SU2)" begin
-        data = ones(4, 6)
-        sa = AbelianSectorArray(
-            (SU2(1 // 2), SU2(1 // 2)), data
-        )
-        @test datalengths(sa) == (2, 3)
-    end
-
-    @testset "sector_type" begin
+    @testset "sectortype" begin
         data = ones(2, 2)
         sa = AbelianSectorArray((U1(1), U1(0)), data)
-        @test sector_type(typeof(sa)) == U1
+        @test sectortype(typeof(sa)) == U1
     end
 
     @testset "AbstractArray interface — size, getindex, setindex!" begin
@@ -116,6 +101,12 @@ using Test: @test, @test_throws, @testset
         data = [1.0 2.0; 3.0 4.0]
         sa = AbelianSectorArray((U1(1), U1(0)), data)
         @test sa isa AbelianSectorMatrix
+    end
+
+    @testset "AbelianSectorVector alias" begin
+        data = [1.0, 2.0, 3.0]
+        sa = AbelianSectorArray((U1(1),), data)
+        @test sa isa AbelianSectorVector
     end
 
     @testset "1D AbelianSectorArray" begin

--- a/test/test_sectoridentity.jl
+++ b/test/test_sectoridentity.jl
@@ -1,5 +1,5 @@
 using GradedArrays:
-    SU2, SectorIdentity, SectorRange, U1, dual, isdual, sector_type, sectoraxes
+    SU2, SectorIdentity, SectorRange, U1, dual, isdual, sectoraxes, sectortype
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @testset
 
@@ -38,8 +38,8 @@ using Test: @test, @testset
         @test axes(si, 2) == U1(1)'
     end
 
-    @testset "sector_type" begin
-        @test sector_type(SectorIdentity{Float64, U1}) == U1
+    @testset "sectortype" begin
+        @test sectortype(SectorIdentity{Float64, U1}) == U1
     end
 
     @testset "getindex — identity matrix (U1, 1×1)" begin

--- a/test/test_sectormatrix.jl
+++ b/test/test_sectormatrix.jl
@@ -1,6 +1,6 @@
 using GradedArrays: GradedArrays, AbelianSectorArray, SU2, SectorIdentity, SectorMatrix,
-    SectorOneTo, SectorRange, U1, data, dataaxes, dual, isdual, sector, sector_type,
-    sectoraxes, ⊗
+    SectorOneTo, SectorRange, U1, data, dataaxes, dual, isdual, sector, sectoraxes,
+    sectortype, ⊗
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @testset
 
@@ -35,9 +35,9 @@ using Test: @test, @testset
         @test si isa SectorIdentity{Float64, U1}
     end
 
-    @testset "sector_type and datatype" begin
+    @testset "sectortype and datatype" begin
         T = SectorMatrix{Float64, Matrix{Float64}, U1}
-        @test sector_type(T) == U1
+        @test sectortype(T) == U1
         @test GradedArrays.datatype(T) == Matrix{Float64}
     end
 

--- a/test/test_sectoroneto.jl
+++ b/test/test_sectoroneto.jl
@@ -1,7 +1,7 @@
 using BlockArrays: blocklength
 using GradedArrays: GradedArrays, GradedOneTo, SU2, SectorOneTo, SectorRange, U1,
-    datalength, datalengths, dual, flip, gradedrange, isdual, sector, sector_type,
-    sectorrange, sectors, tensor_product
+    datalength, datalengths, dual, flip, gradedrange, isdual, sector, sectors, sectortype,
+    tensor_product
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @testset
 
@@ -106,9 +106,9 @@ using Test: @test, @testset
         @test d[si2] == "hello"
     end
 
-    @testset "sector_type" begin
-        @test sector_type(SectorOneTo{U1}) == U1
-        @test sector_type(SectorOneTo{SU2}) == SU2
+    @testset "sectortype" begin
+        @test sectortype(SectorOneTo{U1}) == U1
+        @test sectortype(SectorOneTo{SU2}) == SU2
     end
 
     @testset "show" begin
@@ -128,8 +128,8 @@ using Test: @test, @testset
     end
 
     @testset "tensor_product (abelian)" begin
-        si0 = sectorrange(U1(0), 2)
-        si1 = sectorrange(U1(1), 3)
+        si0 = SectorOneTo(U1(0), 2)
+        si1 = SectorOneTo(U1(1), 3)
 
         tp = tensor_product(si0, si1)
         @test tp isa SectorOneTo
@@ -138,17 +138,17 @@ using Test: @test, @testset
 
         @test tensor_product(si1) == si1
 
-        si1d = sectorrange(U1(1)', 3)
+        si1d = SectorOneTo(U1(1)', 3)
         tp1 = tensor_product(si1d)
         @test !isdual(tp1)
 
-        si = sectorrange(U1(1), 1)
-        @test tensor_product(si, si, si) == sectorrange(U1(3), 1)
-        @test tensor_product(si, si, si, si) == sectorrange(U1(4), 1)
+        si = SectorOneTo(U1(1), 1)
+        @test tensor_product(si, si, si) == SectorOneTo(U1(3), 1)
+        @test tensor_product(si, si, si, si) == SectorOneTo(U1(4), 1)
     end
 
     @testset "tensor_product (non-abelian)" begin
-        si_half = sectorrange(SU2(1 // 2), 1)
+        si_half = SectorOneTo(SU2(1 // 2), 1)
         tp = tensor_product(si_half, si_half)
         @test tp isa GradedOneTo
         @test datalengths(tp) == [1, 1]

--- a/test/test_sectorproduct.jl
+++ b/test/test_sectorproduct.jl
@@ -1,7 +1,7 @@
 using BlockArrays: blocklengths
-using GradedArrays: GradedArrays, SU2, SectorProduct, SectorRange, TrivialSector, U1, Z,
-    arguments, dual, flip, gradedrange, label, sector, sector_type, sectorproduct,
-    sectorrange, tensor_product, trivial, ×
+using GradedArrays: GradedArrays, SU2, SectorOneTo, SectorProduct, SectorRange,
+    TrivialSector, U1, Z, arguments, dual, flip, gradedrange, label, sector, sectorproduct,
+    sectortype, tensor_product, trivial, ×
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @test_broken, @test_throws, @testset
 using TestExtras: @constinferred
@@ -192,11 +192,9 @@ end
         @test_throws ArgumentError s1 × s2
 
         g = gradedrange([(Nf = U1(0),) => 2, (Nf = U1(1),) => 3])
-        @test sector_type(g) <: GradedArrays.SectorRange{<:SectorProduct}
-        sr = sectorrange((; S = SU2(1 // 2)), 1)
+        @test sectortype(g) <: GradedArrays.SectorRange{<:SectorProduct}
+        sr = SectorOneTo(×((; S = SU2(1 // 2))), 1)
         @test length(sr) == 2
-        @test sr == sectorrange(×((; S = SU2(1 // 2))), 1)
-        @test_broken sr == sectorrange(×((; S = SU2(1 // 2))), 1:2)
         g = gradedrange([(; S = SU2(1 // 2)) => 1])
         @test length(g) == 2
         @test g == gradedrange([×((; S = SU2(1 // 2))) => 1])

--- a/test/test_sectors.jl
+++ b/test/test_sectors.jl
@@ -1,5 +1,5 @@
 using GradedArrays: Fib, Ising, O2, SU2, SectorRange, TrivialSector, U1, Z, dual, flip,
-    istrivial, modulus, sector_type, trivial, zero_odd
+    istrivial, modulus, sectortype, trivial, zero_odd
 using SUNRepresentations: SUNRepresentations
 using Test: @test, @test_throws, @testset
 using TestExtras: @constinferred
@@ -11,8 +11,8 @@ fundamental(::Type{SU{N}}) where {N} = SU{N}((1, zeros(Int, N - 2)...))
     @testset "TrivialSector" begin
         q = TrivialSector()
 
-        @test sector_type(q) === TrivialSector
-        @test sector_type(typeof(q)) === TrivialSector
+        @test sectortype(q) === TrivialSector
+        @test sectortype(typeof(q)) === TrivialSector
         @test (@constinferred length(q)) == 1
         @test q == q
         @test trivial(q) == q
@@ -27,8 +27,8 @@ fundamental(::Type{SU{N}}) where {N} = SU{N}((1, zeros(Int, N - 2)...))
         q2 = U1(2)
         q3 = U1(3)
 
-        @test sector_type(q1) === U1
-        @test sector_type(typeof(q1)) === U1
+        @test sectortype(q1) === U1
+        @test sectortype(typeof(q1)) === U1
         @test length(q1) == 1
         @test length(q2) == 1
         @test (@constinferred length(q1)) == 1

--- a/test/test_tensoralgebra.jl
+++ b/test/test_tensoralgebra.jl
@@ -3,8 +3,8 @@ using BlockArrays: Block, blocklength
 using BlockSparseArrays: eachblockstoredindex
 using GradedArrays: AbelianGradedArray, AbelianGradedMatrix, AbelianSectorArray,
     AbelianSectorDelta, FusedGradedMatrix, GradedOneTo, SectorMatrix, SectorOneTo,
-    SectorRange, U1, data, datalengths, dual, flip, gradedrange, isdual, sector,
-    sector_type, sectoraxes, sectormergesort, sectorrange, sectors, tensor_product
+    SectorRange, U1, data, datalengths, dual, flip, gradedrange, isdual, sector, sectoraxes,
+    sectormergesort, sectors, sectortype, tensor_product
 using Random: randn!
 using TensorAlgebra:
     TensorAlgebra, FusionStyle, contract, linearbroadcasted, matricize, unmatricize
@@ -86,17 +86,17 @@ end
     g2 = gradedrange([U1(0) => 1, U1(-1) => 2])
     a = AbelianGradedArray{Float64}(undef, g1, g2)
 
-    # Set a block
-    block_data = randn!(Matrix{Float64}(undef, 2, 2))
-    a[Block(1, 2)] = AbelianSectorArray((U1(0), U1(-1)), block_data)
+    # Set allowed block (2,2): U1(1) × U1(-1) = 0
+    block_data = randn!(Matrix{Float64}(undef, 3, 2))
+    a[Block(2, 2)] = AbelianSectorArray((U1(1), U1(-1)), block_data)
 
     ap = permutedims(a, (2, 1))
     @test ap isa AbelianGradedArray
     @test axes(ap, 1) == g2
     @test axes(ap, 2) == g1
 
-    # The block (1,2) in a should map to block (2,1) in ap
-    ap_block = ap[Block(2, 1)]
+    # The block (2,2) in a should map to block (2,2) in ap
+    ap_block = ap[Block(2, 2)]
     @test Array(ap_block) ≈ permutedims(block_data)
 end
 
@@ -106,16 +106,17 @@ end
     a = AbelianGradedArray{Float64}(undef, g1, g2)
     b = AbelianGradedArray{Float64}(undef, g1, g2)
 
-    block_a = randn!(Matrix{Float64}(undef, 2, 2))
-    block_b = randn!(Matrix{Float64}(undef, 2, 2))
-    a[Block(1, 2)] = AbelianSectorArray((U1(0), U1(-1)), block_a)
-    b[Block(1, 2)] = AbelianSectorArray((U1(0), U1(-1)), block_b)
+    # Use allowed block (2,2): U1(1) × U1(-1) = 0
+    block_a = randn!(Matrix{Float64}(undef, 3, 2))
+    block_b = randn!(Matrix{Float64}(undef, 3, 2))
+    a[Block(2, 2)] = AbelianSectorArray((U1(1), U1(-1)), block_a)
+    b[Block(2, 2)] = AbelianSectorArray((U1(1), U1(-1)), block_b)
 
     α = 2.0
     β = -3.0
     c = α .* a .+ β .* b
     @test c isa AbelianGradedArray
-    c_block = c[Block(1, 2)]
+    c_block = c[Block(2, 2)]
     @test Array(c_block) ≈ α .* block_a .+ β .* block_b
 end
 
@@ -232,19 +233,16 @@ end
 
     mismatched_col_ax = gradedrange([U1(-1) => 3, U1(0) => 2])
     a_mismatched = AbelianGradedArray{Float64}(undef, row_ax, mismatched_col_ax)
-    a_mismatched[Block(1, 1)] =
-        AbelianSectorArray((U1(0), U1(-1)), randn!(Matrix{Float64}(undef, 2, 3)))
-    a_mismatched[Block(2, 2)] =
-        AbelianSectorArray((U1(1), U1(0)), randn!(Matrix{Float64}(undef, 3, 2)))
     @test_throws ArgumentError FusedGradedMatrix(a_mismatched)
 end
 
-@testset "FusedGradedMatrix(::AbelianGradedMatrix) rejects off-diagonal stored blocks" begin
+@testset "Off-diagonal block setindex! errors" begin
     ax = gradedrange([U1(0) => 2, U1(1) => 3])
     a = AbelianGradedArray{Float64}(undef, ax, dual(ax))
-    a[Block(1, 2)] =
-        AbelianSectorArray((U1(0), dual(U1(1))), randn!(Matrix{Float64}(undef, 2, 3)))
-    @test_throws ArgumentError FusedGradedMatrix(a)
+    @test_throws ErrorException (
+        a[Block(1, 2)] =
+            AbelianSectorArray((U1(0), dual(U1(1))), randn!(Matrix{Float64}(undef, 2, 3)))
+    )
 end
 
 @testset "contract 2D AbelianGradedArray (matrix-matrix)" begin


### PR DESCRIPTION
## Summary
- Delete `view!` definitions; blocks either exist or error
- Simplify `getindex` for unstored blocks to error via `copy(view(...))`
- Redesign `AbelianSectorArray` undef constructor to accept `SectorOneTo` axes
- Add `AbelianSectorVector` type alias
- Remove `datalengths(::AbelianSectorArray)` (not needed on single-block types)
- Fix `sectoraxes(::AbelianSectorArray)` to delegate through `sector()`
- Rename `sector_type` → `sectortype` (consistent with `blocktype`, `sectorlength`)
- Rewrite `Base.axes(::AbelianSectorArray)` in terms of `sectoraxes`/`dataaxes`
- Delete `sectorrange()` constructor; use `SectorOneTo` directly
- Rename `⊗` parameter from `A` to `s`
- Remove unused `similar` methods on `AbelianSectorDelta`

## Test plan
- [x] `Pkg.test()` passes (all 17 test files, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)