### PR TITLE
Bug fixes, broadcasting, matricize, and display improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/GradedArrays.jl
+++ b/src/GradedArrays.jl
@@ -25,10 +25,11 @@ import FunctionImplementations as FI
 using BlockArrays: BlockArrays, AbstractBlockArray, AbstractBlockVector,
     AbstractBlockedUnitRange, Block, BlockIndexRange, BlockVector, BlockedOneTo,
     blockedrange, blocklasts, blocklength, blocklengths, blocks, eachblockaxes1
-using BlockSparseArrays:
-    BlockSparseArrays, blockdiagindices, eachblockaxis, eachblockstoredindex, mortar_axis
+using BlockSparseArrays: BlockSparseArrays, blockdiagindices, blockstoredlength,
+    eachblockaxis, eachblockstoredindex, mortar_axis
 using KroneckerArrays: KroneckerArrays, kroneckerfactors, ×, ⊗
 using LinearAlgebra: LinearAlgebra, Adjoint, mul!
+using SparseArraysBase: SparseArraysBase
 using TensorAlgebra: TensorAlgebra, BlockedTuple, FusionStyle, matricize, matricize_axes,
     permutedimsadd!, permutedimsopadd!, tensor_product_axis, trivial_axis, trivialbiperm,
     tryflattenlinear, unmatricize

--- a/src/GradedArrays.jl
+++ b/src/GradedArrays.jl
@@ -23,8 +23,8 @@ export dual, flip, gradedrange, isdual,
 # -------
 import FunctionImplementations as FI
 using BlockArrays: BlockArrays, AbstractBlockArray, AbstractBlockVector, Block,
-    BlockIndexRange, BlockVector, BlockedOneTo, blockedrange, blocklength, blocklengths,
-    blocks, eachblockaxes1
+    BlockIndexRange, BlockVector, BlockedOneTo, block, blockedrange, blockindex,
+    blocklength, blocklengths, blocks, eachblockaxes1, findblockindex
 using BlockSparseArrays:
     BlockSparseArrays, blockdiagindices, eachblockaxis, eachblockstoredindex, mortar_axis
 using KroneckerArrays: KroneckerArrays, kroneckerfactors, ×, ⊗

--- a/src/GradedArrays.jl
+++ b/src/GradedArrays.jl
@@ -22,9 +22,9 @@ export dual, flip, gradedrange, isdual,
 # imports
 # -------
 import FunctionImplementations as FI
-using BlockArrays: BlockArrays, AbstractBlockArray, AbstractBlockVector, Block,
-    BlockIndexRange, BlockVector, BlockedOneTo, block, blockedrange, blockindex,
-    blocklength, blocklengths, blocks, eachblockaxes1, findblockindex
+using BlockArrays: BlockArrays, AbstractBlockArray, AbstractBlockVector,
+    AbstractBlockedUnitRange, Block, BlockIndexRange, BlockVector, BlockedOneTo,
+    blockedrange, blocklasts, blocklength, blocklengths, blocks, eachblockaxes1
 using BlockSparseArrays:
     BlockSparseArrays, blockdiagindices, eachblockaxis, eachblockstoredindex, mortar_axis
 using KroneckerArrays: KroneckerArrays, kroneckerfactors, ×, ⊗

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -129,6 +129,9 @@ function Base.getindex(
         a::AbelianGradedArray{T, N}, I::Vararg{AbstractVector{<:BlockIndexRange{1}}, N}
     ) where {T, N}
     ax_dest = ntuple(d -> axes(a, d)[I[d]], Val(N))
+    # `zero!` is needed: we only copy sub-ranges from stored source blocks,
+    # so destination block regions outside those sub-ranges (and destination
+    # blocks with no source counterpart) must start at 0.
     a_dest = FI.zero!(similar(a, ax_dest))
     # Map source block b → list of (dest BlockIndexRange, src subrange).
     src_to_dests = ntuple(Val(N)) do d
@@ -171,6 +174,9 @@ function Base.getindex(
         a::AbelianGradedArray{T, N}, I::Vararg{AbstractBlockVector{<:Block{1}}, N}
     ) where {T, N}
     ax_dest = ntuple(d -> axes(a, d)[I[d]], Val(N))
+    # `zero!` is needed: each source block writes into a sub-range of one
+    # destination block, so remaining sub-ranges (and destination blocks
+    # with no source counterpart) must start at 0.
     a_dest = FI.zero!(similar(a, ax_dest))
     ax = axes(a)
     # Map source Block → BlockIndexRange encoding dest block + subrange within it
@@ -264,7 +270,9 @@ sectortype(::Type{<:AbelianGradedArray{T, N, D, S}}) where {T, N, D, S} = S
 
 function Base.permutedims(a::AbelianGradedArray{<:Any, N}, perm) where {N}
     dest_axes = ntuple(i -> axes(a)[perm[i]], Val(N))
-    a_dest = FI.zero!(similar(a, dest_axes))
+    # No `zero!` here: `permutedims!` → `permutedimsopadd!(β=0)` already
+    # zeros the destination before writing.
+    a_dest = similar(a, dest_axes)
     return permutedims!(a_dest, a, perm)
 end
 

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -255,7 +255,14 @@ end
 #  fill! / zero! / scale!
 # ---------------------------------------------------------------------------
 
-scale!(a::AbstractArray, β::Number) = (a .*= β; a)
+function scale!(a::AbstractArray, β::Number)
+    if iszero(β)
+        fill!(a, zero(eltype(a)))
+    else
+        a .*= β
+    end
+    return a
+end
 function scale!(a::AbstractGradedArray, β::Number)
     for bI in eachblockstoredindex(a)
         scale!(view(a, bI), β)

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -53,10 +53,11 @@ function AbelianGradedArray{T}(
 end
 
 # Convert any `AbstractGradedMatrix` (e.g. a `FusedGradedMatrix`) to an
-# `AbelianGradedArray` with the same axes and stored blocks. Assumes each
-# allowed block of the target is also stored in `m` — every `similar`
-# allocation is overwritten by the loop below, so no `zero!` is needed.
+# `AbelianGradedArray` with the same axes and stored blocks.
 function AbelianGradedArray(m::AbstractGradedMatrix)
+    # Assumes each allowed block of the target is also stored in `m` — every
+    # `similar` allocation is overwritten by the loop below, so no `zero!`
+    # is needed.
     a = similar(m, axes(m))
     for I in eachblockstoredindex(m)
         a[Data(I)] = view(m, Data(I))

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -52,6 +52,16 @@ function AbelianGradedArray{T}(
     return AbelianGradedArray{T}(init, axs)
 end
 
+# Convert any `AbstractGradedMatrix` (e.g. a `FusedGradedMatrix`) to an
+# `AbelianGradedArray` with the same axes and stored blocks.
+function AbelianGradedArray(m::AbstractGradedMatrix)
+    a = FI.zero!(similar(m, axes(m)))
+    for I in eachblockstoredindex(m)
+        a[Data(I)] = view(m, Data(I))
+    end
+    return a
+end
+
 # ---------------------------------------------------------------------------
 #  AbstractArray interface
 # ---------------------------------------------------------------------------
@@ -312,7 +322,7 @@ end
 function Base.show(io::IO, ::MIME"text/plain", a::AbelianGradedArray)
     summary(io, a)
     println(io, ":")
-    for (d, g) in enumerate(axes(a))
+    for (d, g) in pairs(axes(a))
         print(io, "  Dim $d: ")
         show(io, g)
         println(io)

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -255,14 +255,7 @@ end
 #  fill! / zero! / scale!
 # ---------------------------------------------------------------------------
 
-function scale!(a::AbstractArray, β::Number)
-    if iszero(β)
-        fill!(a, zero(eltype(a)))
-    else
-        a .*= β
-    end
-    return a
-end
+scale!(a::AbstractArray, β::Number) = (a .*= β; a)
 function scale!(a::AbstractGradedArray, β::Number)
     for bI in eachblockstoredindex(a)
         scale!(view(a, bI), β)
@@ -295,12 +288,20 @@ const AbelianGradedMatrix{T, D, S} = AbelianGradedArray{T, 2, D, S}
 #  show
 # ---------------------------------------------------------------------------
 
-function Base.show(io::IO, ::MIME"text/plain", a::AbelianGradedArray{T, N}) where {T, N}
+function Base.summary(io::IO, a::AbelianGradedArray{T, N}) where {T, N}
     block_str = join(map(g -> string(blocklength(g)), axes(a)), "×")
     size_str = join(map(string, size(a)), "×")
     nstored = length(collect(eachblockstoredindex(a)))
     print(io, block_str, "-blocked ", size_str, " AbelianGradedArray{", T, "}")
     print(io, " with ", nstored, " stored block", nstored == 1 ? "" : "s")
+    return nothing
+end
+
+function Base.show(io::IO, ::MIME"text/plain", a::AbelianGradedArray)
+    summary(io, a)
+    isempty(a) && return nothing
+    println(io, ":")
+    Base.print_array(io, a)
     return nothing
 end
 

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -53,9 +53,11 @@ function AbelianGradedArray{T}(
 end
 
 # Convert any `AbstractGradedMatrix` (e.g. a `FusedGradedMatrix`) to an
-# `AbelianGradedArray` with the same axes and stored blocks.
+# `AbelianGradedArray` with the same axes and stored blocks. Assumes each
+# allowed block of the target is also stored in `m` — every `similar`
+# allocation is overwritten by the loop below, so no `zero!` is needed.
 function AbelianGradedArray(m::AbstractGradedMatrix)
-    a = FI.zero!(similar(m, axes(m)))
+    a = similar(m, axes(m))
     for I in eachblockstoredindex(m)
         a[Data(I)] = view(m, Data(I))
     end

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -294,6 +294,10 @@ function Base.summary(io::IO, a::AbelianGradedArray{T, N}) where {T, N}
     nstored = length(collect(eachblockstoredindex(a)))
     print(io, block_str, "-blocked ", size_str, " AbelianGradedArray{", T, "}")
     print(io, " with ", nstored, " stored block", nstored == 1 ? "" : "s")
+    for (d, g) in enumerate(axes(a))
+        print(io, "\n  Dim $d: ")
+        show(io, g)
+    end
     return nothing
 end
 

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -288,31 +288,32 @@ const AbelianGradedMatrix{T, D, S} = AbelianGradedArray{T, 2, D, S}
 #  show
 # ---------------------------------------------------------------------------
 
-function Base.summary(io::IO, a::AbelianGradedArray{T, N}) where {T, N}
+function Base.summary(io::IO, a::AbelianGradedArray)
     block_str = join(map(g -> string(blocklength(g)), axes(a)), "×")
     size_str = join(map(string, size(a)), "×")
     nstored = length(collect(eachblockstoredindex(a)))
-    print(io, block_str, "-blocked ", size_str, " AbelianGradedArray{", T, "}")
+    print(io, block_str, "-blocked ", size_str, " ", typeof(a))
     print(io, " with ", nstored, " stored block", nstored == 1 ? "" : "s")
-    for (d, g) in enumerate(axes(a))
-        print(io, "\n  Dim $d: ")
-        show(io, g)
-    end
     return nothing
 end
 
 function Base.show(io::IO, ::MIME"text/plain", a::AbelianGradedArray)
     summary(io, a)
-    isempty(a) && return nothing
     println(io, ":")
+    for (d, g) in enumerate(axes(a))
+        print(io, "  Dim $d: ")
+        show(io, g)
+        println(io)
+    end
+    isempty(a) && return nothing
     Base.print_array(io, a)
     return nothing
 end
 
-function Base.show(io::IO, a::AbelianGradedArray{T, N}) where {T, N}
+function Base.show(io::IO, a::AbelianGradedArray)
     block_str = join(map(g -> string(blocklength(g)), axes(a)), "×")
     size_str = join(map(string, size(a)), "×")
-    print(io, block_str, "-blocked ", size_str, " AbelianGradedArray{", T, "}")
+    print(io, block_str, "-blocked ", size_str, " ", typeof(a))
     return nothing
 end
 

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -198,6 +198,18 @@ function BlockSparseArrays.eachblockstoredindex(a::AbelianGradedArray{T, N}) whe
     return (Block(k) for k in keys(a.blockdata))
 end
 
+# Implement the `SparseArraysBase` interface on `AbelianBlocks` (the lazy
+# block view) so that `storedlength(blocks(a))` — and by extension
+# `blockstoredlength(a)` — reflects the dict-of-keys storage rather than
+# treating every slot as stored.
+function SparseArraysBase.eachstoredindex(b::AbelianBlocks{T, N}) where {T, N}
+    return (CartesianIndex(k) for k in keys(b.parent.blockdata))
+end
+SparseArraysBase.storedvalues(b::AbelianBlocks) = values(b.parent.blockdata)
+function SparseArraysBase.isstored(b::AbelianBlocks{T, N}, I::Vararg{Int, N}) where {T, N}
+    return haskey(b.parent.blockdata, I)
+end
+
 # ---------------------------------------------------------------------------
 #  similar
 # ---------------------------------------------------------------------------
@@ -291,7 +303,7 @@ const AbelianGradedMatrix{T, D, S} = AbelianGradedArray{T, 2, D, S}
 function Base.summary(io::IO, a::AbelianGradedArray)
     block_str = join(map(g -> string(blocklength(g)), axes(a)), "×")
     size_str = join(map(string, size(a)), "×")
-    nstored = length(collect(eachblockstoredindex(a)))
+    nstored = blockstoredlength(a)
     print(io, block_str, "-blocked ", size_str, " ", typeof(a))
     print(io, " with ", nstored, " stored block", nstored == 1 ? "" : "s")
     return nothing

--- a/src/abeliansectordelta.jl
+++ b/src/abeliansectordelta.jl
@@ -106,7 +106,7 @@ function fermion_contraction_phase(
     length_codomain <= ndims(x) ||
         throw(ArgumentError(lazy"Cannot contract more than ndim legs ($N > $(ndims(x))"))
 
-    parity = mapreduce(⊻, enumerate(axes(x))) do (n, ax)
+    parity = mapreduce(⊻, pairs(axes(x))) do (n, ax)
         return (n <= length_codomain) & isdual(ax) & fermionparity(ax)
     end
     return ifelse(parity, -1, 1)

--- a/src/abstractgradedarray.jl
+++ b/src/abstractgradedarray.jl
@@ -83,18 +83,17 @@ end
 # ---------------------------------------------------------------------------
 
 using BlockSparseArrays: BlockSparseArray
-using LinearAlgebra: kron
 
-function _to_blocksparsearray(a::AbstractGradedMatrix{T}) where {T}
+function _to_blocksparsearray(a::AbstractGradedArray{T, N}) where {T, N}
     blocked_axes = map(g -> blockedrange(blocklengths(g)), axes(a))
     bsa = BlockSparseArray{T}(undef, blocked_axes)
     for bI in eachblockstoredindex(a)
         blk = view(a, bI)
-        bsa[bI] = kron(Array(sector(blk)), data(blk))
+        bsa[bI] = collect(Array(sector(blk)) ⊗ data(blk))
     end
     return bsa
 end
 
-function Base.print_array(io::IO, a::AbstractGradedMatrix)
+function Base.print_array(io::IO, a::AbstractGradedArray)
     return Base.print_array(io, _to_blocksparsearray(a))
 end

--- a/src/abstractgradedarray.jl
+++ b/src/abstractgradedarray.jl
@@ -79,58 +79,22 @@ function Base.setindex!(
 end
 
 # ---------------------------------------------------------------------------
-#  Display — convert to BlockedOneTo axes for block-structured printing
+#  Display — convert to BlockSparseArray for printing
 # ---------------------------------------------------------------------------
 
-function _block_is_stored(a::AbstractGradedArray, bI::Block)
-    return any(==(bI), eachblockstoredindex(a))
-end
+using BlockSparseArrays: BlockSparseArray
+using LinearAlgebra: kron
 
-# Lightweight wrapper that provides BlockedOneTo axes and scalar getindex
-# for Base/BlockArrays printing infrastructure.
-struct _GradedPrintView{T, A <: AbstractGradedMatrix{T}} <: AbstractMatrix{T}
-    parent::A
-    rowaxis::BlockedOneTo{Int, Vector{Int}}
-    colaxis::BlockedOneTo{Int, Vector{Int}}
-end
-
-function _GradedPrintView(a::AbstractGradedMatrix)
-    rax = blockedrange(blocklengths(axes(a, 1)))
-    cax = blockedrange(blocklengths(axes(a, 2)))
-    return _GradedPrintView{eltype(a), typeof(a)}(a, rax, cax)
-end
-
-Base.size(p::_GradedPrintView) = size(p.parent)
-Base.axes(p::_GradedPrintView) = (p.rowaxis, p.colaxis)
-
-function Base.getindex(p::_GradedPrintView{T}, i::Int, j::Int) where {T}
-    @boundscheck checkbounds(p, i, j)
-    bi = findblockindex(p.rowaxis, i)
-    bj = findblockindex(p.colaxis, j)
-    bI = Block(Int(block(bi)), Int(block(bj)))
-    _block_is_stored(p.parent, bI) || return zero(T)
-    blk = view(p.parent, bI)
-    return @inbounds blk[blockindex(bi), blockindex(bj)]
-end
-
-function Base.replace_in_print_matrix(
-        p::_GradedPrintView, i::Integer, j::Integer, s::AbstractString
-    )
-    bi = findblockindex(p.rowaxis, i)
-    bj = findblockindex(p.colaxis, j)
-    bI = Block(Int(block(bi)), Int(block(bj)))
-    return _block_is_stored(p.parent, bI) ? s : Base.replace_with_centered_mark(s)
-end
-
-# Delegate to BlockArrays' block-structured row printing for separators.
-function Base.print_matrix_row(
-        io::IO, X::_GradedPrintView, A::Vector,
-        i::Integer, cols::AbstractVector, sep::AbstractString,
-        idxlast::Integer = last(axes(X, 2))
-    )
-    return BlockArrays._blockarray_print_matrix_row(io, X, A, i, cols, sep)
+function _to_blocksparsearray(a::AbstractGradedMatrix{T}) where {T}
+    blocked_axes = map(g -> blockedrange(blocklengths(g)), axes(a))
+    bsa = BlockSparseArray{T}(undef, blocked_axes)
+    for bI in eachblockstoredindex(a)
+        blk = view(a, bI)
+        bsa[bI] = kron(Array(sector(blk)), data(blk))
+    end
+    return bsa
 end
 
 function Base.print_array(io::IO, a::AbstractGradedMatrix)
-    return Base.print_array(io, _GradedPrintView(a))
+    return Base.print_array(io, _to_blocksparsearray(a))
 end

--- a/src/abstractgradedarray.jl
+++ b/src/abstractgradedarray.jl
@@ -77,3 +77,60 @@ function Base.setindex!(
     view(a, I) .= value
     return a
 end
+
+# ---------------------------------------------------------------------------
+#  Display — convert to BlockedOneTo axes for block-structured printing
+# ---------------------------------------------------------------------------
+
+function _block_is_stored(a::AbstractGradedArray, bI::Block)
+    return any(==(bI), eachblockstoredindex(a))
+end
+
+# Lightweight wrapper that provides BlockedOneTo axes and scalar getindex
+# for Base/BlockArrays printing infrastructure.
+struct _GradedPrintView{T, A <: AbstractGradedMatrix{T}} <: AbstractMatrix{T}
+    parent::A
+    rowaxis::BlockedOneTo{Int, Vector{Int}}
+    colaxis::BlockedOneTo{Int, Vector{Int}}
+end
+
+function _GradedPrintView(a::AbstractGradedMatrix)
+    rax = blockedrange(blocklengths(axes(a, 1)))
+    cax = blockedrange(blocklengths(axes(a, 2)))
+    return _GradedPrintView{eltype(a), typeof(a)}(a, rax, cax)
+end
+
+Base.size(p::_GradedPrintView) = size(p.parent)
+Base.axes(p::_GradedPrintView) = (p.rowaxis, p.colaxis)
+
+function Base.getindex(p::_GradedPrintView{T}, i::Int, j::Int) where {T}
+    @boundscheck checkbounds(p, i, j)
+    bi = findblockindex(p.rowaxis, i)
+    bj = findblockindex(p.colaxis, j)
+    bI = Block(Int(block(bi)), Int(block(bj)))
+    _block_is_stored(p.parent, bI) || return zero(T)
+    blk = view(p.parent, bI)
+    return @inbounds blk[blockindex(bi), blockindex(bj)]
+end
+
+function Base.replace_in_print_matrix(
+        p::_GradedPrintView, i::Integer, j::Integer, s::AbstractString
+    )
+    bi = findblockindex(p.rowaxis, i)
+    bj = findblockindex(p.colaxis, j)
+    bI = Block(Int(block(bi)), Int(block(bj)))
+    return _block_is_stored(p.parent, bI) ? s : Base.replace_with_centered_mark(s)
+end
+
+# Delegate to BlockArrays' block-structured row printing for separators.
+function Base.print_matrix_row(
+        io::IO, X::_GradedPrintView, A::Vector,
+        i::Integer, cols::AbstractVector, sep::AbstractString,
+        idxlast::Integer = last(axes(X, 2))
+    )
+    return BlockArrays._blockarray_print_matrix_row(io, X, A, i, cols, sep)
+end
+
+function Base.print_array(io::IO, a::AbstractGradedMatrix)
+    return Base.print_array(io, _GradedPrintView(a))
+end

--- a/src/abstractsectorarray.jl
+++ b/src/abstractsectorarray.jl
@@ -53,3 +53,26 @@ function FI.zero!(a::AbstractSectorArray)
     FI.zero!(data(a))
     return a
 end
+
+# ========================  display  ========================
+
+function Base.print_array(io::IO, sa::AbstractSectorArray)
+    Base.print_array(io, sector(sa))
+    println(io, "\n ⊗")
+    Base.print_array(io, data(sa))
+    return nothing
+end
+
+function Base.show(io::IO, sa::AbstractSectorArray)
+    show(io, sector(sa))
+    print(io, " ⊗ ")
+    show(io, data(sa))
+    return nothing
+end
+
+function Base.show(io::IO, ::MIME"text/plain", sa::AbstractSectorArray)
+    summary(io, sa)
+    println(io, ":")
+    Base.print_array(io, sa)
+    return nothing
+end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -52,39 +52,39 @@ function Base.copyto!(dest::AbstractSectorArray, bc::BC.Broadcasted{<:SectorStyl
     return dest
 end
 
-# ========================  AbelianGradedArray broadcasting  ========================
+# ========================  GradedArray broadcasting  ========================
 
-struct AbelianGradedStyle{N} <: BC.AbstractArrayStyle{N} end
-AbelianGradedStyle{N}(::Val{M}) where {N, M} = AbelianGradedStyle{M}()
+struct GradedStyle{N} <: BC.AbstractArrayStyle{N} end
+GradedStyle{N}(::Val{M}) where {N, M} = GradedStyle{M}()
 
-function BC.BroadcastStyle(::Type{<:AbelianGradedArray{<:Any, N}}) where {N}
-    return AbelianGradedStyle{N}()
+function BC.BroadcastStyle(::Type{<:AbstractGradedArray{<:Any, N}}) where {N}
+    return GradedStyle{N}()
 end
 function BC.BroadcastStyle(
-        style::AbelianGradedStyle{N},
+        style::GradedStyle{N},
         ::BC.DefaultArrayStyle{0}
     ) where {N}
     return style
 end
 function BC.BroadcastStyle(
         ::BC.DefaultArrayStyle{0},
-        style::AbelianGradedStyle{N}
+        style::GradedStyle{N}
     ) where {N}
     return style
 end
-BC.BroadcastStyle(s1::AbelianGradedStyle{N}, ::AbelianGradedStyle{N}) where {N} = s1
+BC.BroadcastStyle(s1::GradedStyle{N}, ::GradedStyle{N}) where {N} = s1
 
 # TODO: Ideally this would incorporate information from all broadcast arguments
 # (or their blocktypes) when computing similar, rather than picking one argument.
-function Base.similar(bc::BC.Broadcasted{<:AbelianGradedStyle}, elt::Type)
+function Base.similar(bc::BC.Broadcasted{<:GradedStyle}, elt::Type)
     bc′ = BC.flatten(bc)
-    arg = bc′.args[findfirst(arg -> arg isa AbelianGradedArray, bc′.args)]
+    arg = bc′.args[findfirst(arg -> arg isa AbstractGradedArray, bc′.args)]
     return similar(arg, elt)
 end
 
-function Base.copyto!(dest::AbelianGradedArray, bc::BC.Broadcasted{<:AbelianGradedStyle})
+function Base.copyto!(dest::AbstractGradedArray, bc::BC.Broadcasted{<:GradedStyle})
     lb = tryflattenlinear(bc)
     isnothing(lb) &&
-        throw(ArgumentError("AbelianGradedArray broadcasting requires linear operations"))
+        throw(ArgumentError("AbstractGradedArray broadcasting requires linear operations"))
     return copyto!(dest, lb)
 end

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -220,8 +220,13 @@ end
 
 function Base.show(io::IO, ::MIME"text/plain", m::FusedGradedMatrix)
     summary(io, m)
-    isempty(m.sectors) && return nothing
     println(io, ":")
+    for (d, g) in enumerate(axes(m))
+        print(io, "  Dim $d: ")
+        show(io, g)
+        println(io)
+    end
+    isempty(m.sectors) && return nothing
     Base.print_array(io, m)
     return nothing
 end

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -189,7 +189,7 @@ function Base.show(io::IO, ::MIME"text/plain", m::FusedGradedMatrix{T}) where {T
     nblocks = length(m.sectors)
     print(io, nblocks, "-block FusedGradedMatrix{", T, "} with sectors ")
     print(io, "[")
-    join(io, label.(m.sectors), ", ")
+    join(io, m.sectors, ", ")
     print(io, "]")
     return nothing
 end

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -143,11 +143,17 @@ end
 
 # ========================  mul!  ========================
 
-function check_mul_axes(
-        C::FusedGradedMatrix, A::FusedGradedMatrix, B::FusedGradedMatrix
-    )
+function check_input(::typeof(*), A::FusedGradedMatrix, B::FusedGradedMatrix)
     axes(A, 2) == dual(axes(B, 1)) ||
         throw(DimensionMismatch("sector mismatch in contracted dimension"))
+    return nothing
+end
+
+function check_input(
+        ::typeof(mul!),
+        C::FusedGradedMatrix, A::FusedGradedMatrix, B::FusedGradedMatrix
+    )
+    check_input(*, A, B)
     axes(C, 1) == axes(A, 1) || throw(DimensionMismatch())
     axes(C, 2) == axes(B, 2) || throw(DimensionMismatch())
     return nothing
@@ -157,7 +163,7 @@ function LinearAlgebra.mul!(
         C::FusedGradedMatrix, A::FusedGradedMatrix, B::FusedGradedMatrix,
         α::Number, β::Number
     )
-    check_mul_axes(C, A, B)
+    check_input(mul!, C, A, B)
     for I in blockdiagindices(C)
         mul!(view(C, Data(I)), view(A, Data(I)), view(B, Data(I)), α, β)
     end
@@ -177,28 +183,9 @@ function allocate_output(::typeof(*), A::FusedGradedMatrix, B::FusedGradedMatrix
 end
 
 function Base.:(*)(A::FusedGradedMatrix, B::FusedGradedMatrix)
-    if A.sectors == B.sectors
-        C = allocate_output(*, A, B)
-        return mul!(C, A, B)
-    end
-    return _mul_mismatched(A, B)
-end
-
-# Multiply two FusedGradedMatrix objects whose sector sets may differ.
-# Only sectors present in both A and B contribute; sectors in only one
-# operand produce zero blocks that are dropped from the result.
-function _mul_mismatched(A::FusedGradedMatrix, B::FusedGradedMatrix)
-    T = Base.promote_op(*, eltype(A), eltype(B))
-    b_dict = Dict(s => i for (i, s) in enumerate(B.sectors))
-    result_sectors = empty(A.sectors)
-    result_blocks = Matrix{T}[]
-    for (ia, sa) in enumerate(A.sectors)
-        ib = get(b_dict, sa, nothing)
-        isnothing(ib) && continue
-        push!(result_sectors, sa)
-        push!(result_blocks, A.blocks[ia] * B.blocks[ib])
-    end
-    return FusedGradedMatrix(result_sectors, result_blocks)
+    check_input(*, A, B)
+    C = allocate_output(*, A, B)
+    return mul!(C, A, B)
 end
 
 # ========================  similar  ========================
@@ -265,14 +252,23 @@ end
 
 """
     AbelianGradedArray(m::FusedGradedMatrix)
+    AbelianGradedArray(m::FusedGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo)
 
-Convert a `FusedGradedMatrix` to a 2D `AbelianGradedArray`.
-Inverse of `FusedGradedMatrix(::AbelianGradedArray)`.
+Convert a `FusedGradedMatrix` to a 2D `AbelianGradedArray`. With explicit
+axes given, the result has those axes; sectors of `m` whose dual is absent
+from `dom_ax` (or whose sector is absent from `cod_ax`) are dropped, and
+target sectors absent from `m` become unstored blocks.
 """
-function AbelianGradedArray(m::FusedGradedMatrix{T}) where {T}
-    a = similar(m, axes(m))
-    for I in blockdiagindices(m)
-        a[Data(I)] = view(m, Data(I))
+function AbelianGradedArray(m::FusedGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo)
+    a = FI.zero!(similar(m, (cod_ax, dom_ax)))
+    cod_pos = Dict(s => i for (i, s) in enumerate(sectors(cod_ax)))
+    dom_pos = Dict(s => j for (j, s) in enumerate(sectors(dom_ax)))
+    for (k, s) in enumerate(m.sectors)
+        i = get(cod_pos, s, nothing)
+        j = get(dom_pos, dual(s), nothing)
+        (isnothing(i) || isnothing(j)) && continue
+        a[Data(i, j)] = m.blocks[k]
     end
     return a
 end
+AbelianGradedArray(m::FusedGradedMatrix) = AbelianGradedArray(m, axes(m)...)

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -40,6 +40,11 @@ function FusedGradedMatrix(
     ) where {T, S <: SectorRange, D <: AbstractMatrix{T}}
     return FusedGradedMatrix{T, D, S}(sectors, blocks)
 end
+function FusedGradedMatrix(pairs::AbstractVector{<:Pair})
+    sectors = first.(pairs)
+    blocks = last.(pairs)
+    return FusedGradedMatrix(sectors, blocks)
+end
 
 # ========================  undef constructors  ========================
 

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -208,7 +208,7 @@ end
 function Base.show(io::IO, ::MIME"text/plain", m::FusedGradedMatrix)
     summary(io, m)
     println(io, ":")
-    for (d, g) in enumerate(axes(m))
+    for (d, g) in pairs(axes(m))
         print(io, "  Dim $d: ")
         show(io, g)
         println(io)
@@ -249,26 +249,3 @@ function FusedGradedMatrix(a::AbelianGradedMatrix{T}) where {T}
     end
     return m
 end
-
-"""
-    AbelianGradedArray(m::FusedGradedMatrix)
-    AbelianGradedArray(m::FusedGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo)
-
-Convert a `FusedGradedMatrix` to a 2D `AbelianGradedArray`. With explicit
-axes given, the result has those axes; sectors of `m` whose dual is absent
-from `dom_ax` (or whose sector is absent from `cod_ax`) are dropped, and
-target sectors absent from `m` become unstored blocks.
-"""
-function AbelianGradedArray(m::FusedGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo)
-    a = FI.zero!(similar(m, (cod_ax, dom_ax)))
-    cod_pos = Dict(s => i for (i, s) in enumerate(sectors(cod_ax)))
-    dom_pos = Dict(s => j for (j, s) in enumerate(sectors(dom_ax)))
-    for (k, s) in enumerate(m.sectors)
-        i = get(cod_pos, s, nothing)
-        j = get(dom_pos, dual(s), nothing)
-        (isnothing(i) || isnothing(j)) && continue
-        a[Data(i, j)] = m.blocks[k]
-    end
-    return a
-end
-AbelianGradedArray(m::FusedGradedMatrix) = AbelianGradedArray(m, axes(m)...)

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -210,10 +210,9 @@ end
 
 # ========================  show  ========================
 
-function Base.summary(io::IO, m::FusedGradedMatrix{T}) where {T}
+function Base.summary(io::IO, m::FusedGradedMatrix)
     nblocks = length(m.sectors)
-    print(io, nblocks, "-block FusedGradedMatrix{", T, "} with sectors ")
-    print(io, "[")
+    print(io, nblocks, "-block ", typeof(m), " with sectors [")
     join(io, m.sectors, ", ")
     print(io, "]")
     return nothing
@@ -227,9 +226,9 @@ function Base.show(io::IO, ::MIME"text/plain", m::FusedGradedMatrix)
     return nothing
 end
 
-function Base.show(io::IO, m::FusedGradedMatrix{T}) where {T}
+function Base.show(io::IO, m::FusedGradedMatrix)
     nblocks = length(m.sectors)
-    print(io, nblocks, "-block FusedGradedMatrix{", T, "}")
+    print(io, nblocks, "-block ", typeof(m))
     return nothing
 end
 

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -177,8 +177,28 @@ function allocate_output(::typeof(*), A::FusedGradedMatrix, B::FusedGradedMatrix
 end
 
 function Base.:(*)(A::FusedGradedMatrix, B::FusedGradedMatrix)
-    C = allocate_output(*, A, B)
-    return mul!(C, A, B)
+    if A.sectors == B.sectors
+        C = allocate_output(*, A, B)
+        return mul!(C, A, B)
+    end
+    return _mul_mismatched(A, B)
+end
+
+# Multiply two FusedGradedMatrix objects whose sector sets may differ.
+# Only sectors present in both A and B contribute; sectors in only one
+# operand produce zero blocks that are dropped from the result.
+function _mul_mismatched(A::FusedGradedMatrix, B::FusedGradedMatrix)
+    T = Base.promote_op(*, eltype(A), eltype(B))
+    b_dict = Dict(s => i for (i, s) in enumerate(B.sectors))
+    result_sectors = empty(A.sectors)
+    result_blocks = Matrix{T}[]
+    for (ia, sa) in enumerate(A.sectors)
+        ib = get(b_dict, sa, nothing)
+        isnothing(ib) && continue
+        push!(result_sectors, sa)
+        push!(result_blocks, A.blocks[ia] * B.blocks[ib])
+    end
+    return FusedGradedMatrix(result_sectors, result_blocks)
 end
 
 # ========================  similar  ========================
@@ -190,12 +210,20 @@ end
 
 # ========================  show  ========================
 
-function Base.show(io::IO, ::MIME"text/plain", m::FusedGradedMatrix{T}) where {T}
+function Base.summary(io::IO, m::FusedGradedMatrix{T}) where {T}
     nblocks = length(m.sectors)
     print(io, nblocks, "-block FusedGradedMatrix{", T, "} with sectors ")
     print(io, "[")
     join(io, m.sectors, ", ")
     print(io, "]")
+    return nothing
+end
+
+function Base.show(io::IO, ::MIME"text/plain", m::FusedGradedMatrix)
+    summary(io, m)
+    isempty(m.sectors) && return nothing
+    println(io, ":")
+    Base.print_array(io, m)
     return nothing
 end
 

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -141,55 +141,30 @@ end
 
 # ========================  pad_to_canonical_duals  ========================
 
-# Pad an AbelianGradedMatrix so its codomain and domain axes form canonical duals.
-# After sectormergesort, the codomain (non-dual) and domain (dual) axes are sorted
-# but may have different sector sets. This adds zero-multiplicity entries for
-# missing sectors so that `sectors(axis1) == dual.(sectors(axis2))`.
-function pad_to_canonical_duals(a::AbelianGradedMatrix{T}) where {T}
-    ax_cod = axes(a, 1)
-    ax_dom = axes(a, 2)
-
-    cod_sects = sectors(ax_cod)
-    dom_sects = sectors(ax_dom)
-
-    # Fast path: already canonical duals
+# Pad an `AbelianGradedMatrix` so the codomain and domain axes carry the same
+# (non-dual) sector list — i.e. `sectors(axes(a,1)) == dual.(sectors(axes(a,2)))`.
+# Sectors that appear only on one side get a multiplicity-0 entry on the other.
+# Stored blocks are re-placed at their new sector indices.
+function pad_to_canonical_duals(a::AbelianGradedMatrix)
+    cod_sects = sectors(axes(a, 1))
+    dom_sects = sectors(axes(a, 2))
     cod_sects == dual.(dom_sects) && return a
 
-    # Compute the union of codomain sectors and dual(domain sectors), all non-dual.
-    # Both inputs are sorted after sectormergesort.
-    cod_nondual = collect(cod_sects)
-    dom_nondual = collect(dual.(dom_sects))
-    all_sects = sort!(unique!([cod_nondual; dom_nondual]))
+    canonical = sort!(unique!(vcat(collect(cod_sects), dual.(collect(dom_sects)))))
+    cod_lens = Dict(zip(cod_sects, datalengths(axes(a, 1))))
+    dom_lens = Dict(zip(dom_sects, datalengths(axes(a, 2))))
+    cod′ = gradedrange([s => get(cod_lens, s, 0) for s in canonical])
+    dom′ = gradedrange([dual(s) => get(dom_lens, dual(s), 0) for s in canonical])
 
-    # Build padded codomain axis (non-dual): existing datalengths for known sectors,
-    # zero for missing ones.
-    cod_dlens = GradedArrays.datalengths(ax_cod)
-    dom_dlens = GradedArrays.datalengths(ax_dom)
-
-    cod_dict = Dict(zip(cod_sects, cod_dlens))
-    dom_dict = Dict(zip(dom_sects, dom_dlens))
-
-    padded_cod_pairs = [s => get(cod_dict, s, 0) for s in all_sects]
-    padded_dom_pairs = [dual(s) => get(dom_dict, dual(s), 0) for s in all_sects]
-
-    padded_cod = gradedrange(padded_cod_pairs)
-    padded_dom = gradedrange(padded_dom_pairs)
-
-    # Allocate padded matrix with zero-initialized blocks.
-    a_padded = GradedArrays.FI.zero!(similar(a, (padded_cod, padded_dom)))
-
-    # Copy existing blocks. Map old block indices to new block indices via sector lookup.
-    cod_idx = Dict(s => i for (i, s) in enumerate(all_sects))
-    dom_idx = Dict(dual(s) => i for (i, s) in enumerate(all_sects))
-
-    for bI in eachblockstoredindex(a)
-        old_row, old_col = Int.(Tuple(bI))
-        new_row = cod_idx[cod_sects[old_row]]
-        new_col = dom_idx[dom_sects[old_col]]
-        copyto!(data(view(a_padded, Block(new_row, new_col))), data(a[bI]))
+    a′ = FI.zero!(similar(a, (cod′, dom′)))
+    pos = Dict(s => i for (i, s) in enumerate(canonical))
+    for I in eachblockstoredindex(a)
+        i, j = Int.(Tuple(I))
+        new_i = pos[cod_sects[i]]
+        new_j = pos[dual(dom_sects[j])]
+        a′[Data(new_i, new_j)] = data(a[I])
     end
-
-    return a_padded
+    return a′
 end
 
 # ========================  SectorFusion AbelianGradedArray matricize  ========================
@@ -272,54 +247,21 @@ end
 
 # ========================  SectorFusion FusedGradedMatrix unmatricize  ========================
 
-# Pad a FusedGradedMatrix to have the given codomain and domain axes.
-# Existing blocks are copied; missing sectors get zero-size blocks (0xN or Nx0).
-function _pad_fused(
-        m::FusedGradedMatrix{T},
-        cod_ax::GradedOneTo,
-        dom_ax::GradedOneTo
-    ) where {T}
-    expected_sects = sectors(cod_ax)
-    expected_cod_dlens = datalengths(cod_ax)
-    expected_dom_dlens = datalengths(dom_ax)
-
-    # Fast path: already matches
-    m.sectors == expected_sects && return m
-
-    m_dict = Dict(s => i for (i, s) in enumerate(m.sectors))
-    new_sectors = collect(expected_sects)
-    new_blocks = Matrix{T}[]
-    for (i, s) in enumerate(expected_sects)
-        j = get(m_dict, s, nothing)
-        if isnothing(j)
-            push!(new_blocks, zeros(T, expected_cod_dlens[i], expected_dom_dlens[i]))
-        else
-            push!(new_blocks, m.blocks[j])
-        end
-    end
-    return FusedGradedMatrix(new_sectors, new_blocks)
-end
-
 function TensorAlgebra.unmatricize(
         ::SectorFusion, m::FusedGradedMatrix,
         codomain_axes::Tuple{Vararg{GradedOneTo}},
         domain_axes::Tuple{Vararg{GradedOneTo}}
     )
-    blocked_axes = (codomain_axes..., domain_axes...)
-    if isempty(blocked_axes)
+    isempty((codomain_axes..., domain_axes...)) &&
         error("Scalar unmatricize not yet supported for FusedGradedMatrix")
-    end
-
-    # Compute the unfused 2D axes that the N-D blocked axes produce.
+    # Compute the unfused 2D axes the N-D blocked axes produce, then their
+    # sector-merged form (the axes matricize would have produced).
     unfused_axes = matricize_axes(BlockReshapeFusion(), m, codomain_axes, domain_axes)
-    # Merge-sort the unfused axes to get the expected merged axes.
-    expected_cod = sectormergesort(unfused_axes[1])
-    expected_dom = sectormergesort(unfused_axes[2])
-    # Pad m so its axes match the expected merged axes (adds zero-size blocks
-    # for sectors absent from the multiplication result).
-    m_padded = _pad_fused(m, expected_cod, expected_dom)
-
-    m_abelian = AbelianGradedArray(m_padded)
+    merged_cod = sectormergesort(unfused_axes[1])
+    merged_dom = sectormergesort(unfused_axes[2])
+    # Build an `AbelianGradedMatrix` directly with those merged axes (sectors
+    # in `merged_*` but not in `m.sectors` simply land as unstored blocks).
+    m_abelian = AbelianGradedArray(m, merged_cod, merged_dom)
     blockperms = sectorsortperm.(unfused_axes)
     J = map(invblockmergeperm, unfused_axes, blockperms, axes(m_abelian))
     m_split = m_abelian[J...]

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -139,15 +139,32 @@ function TensorAlgebra.matricize(
     return a_2d
 end
 
-# ========================  pad_to_canonical_duals  ========================
+# ========================  insert_missing_sectors  ========================
 
-# Pad an `AbelianGradedMatrix` so the codomain and domain axes carry the same
-# (non-dual) sector list — i.e. `sectors(axes(a,1)) == dual.(sectors(axes(a,2)))`.
-# Sectors that appear only on one side get a multiplicity-0 entry on the other.
-# Stored blocks are re-placed at their new sector indices.
-function pad_to_canonical_duals(a::AbelianGradedMatrix)
+# Reshape an `AbelianGradedMatrix` so the codomain and domain axes carry the
+# same (non-dual) sector list — i.e. `sectors(axes(a,1)) == dual.(sectors(axes(a,2)))`
+# — by inserting a multiplicity-0 entry wherever a sector is present on one
+# axis but not the other. Stored blocks are re-placed at the corresponding
+# sector indices (which may involve both insertion and permutation if the
+# input axes aren't already sorted consistently with `dual`).
+#
+# Requires each axis to have sorted, unique sectors (as produced by
+# `sectormergesort`); repeated sectors on one axis would be silently collapsed
+# by the dict-based multiplicity lookup below, and the sorted-insertion logic
+# (via `sort!(vcat(...))`) would reorder blocks unexpectedly otherwise.
+function insert_missing_sectors(a::AbelianGradedMatrix)
     cod_sects = sectors(axes(a, 1))
     dom_sects = sectors(axes(a, 2))
+    (issorted(cod_sects) && allunique(cod_sects)) ||
+        throw(
+        ArgumentError(
+            "insert_missing_sectors requires sorted, unique codomain sectors"
+        )
+    )
+    (issorted(dual.(dom_sects)) && allunique(dom_sects)) ||
+        throw(
+        ArgumentError("insert_missing_sectors requires sorted, unique domain sectors")
+    )
     cod_sects == dual.(dom_sects) && return a
 
     canonical = sort!(unique!(vcat(collect(cod_sects), dual.(collect(dom_sects)))))
@@ -173,8 +190,7 @@ function TensorAlgebra.matricize(
     ) where {K}
     a_reshaped = matricize(BlockReshapeFusion(), a, ndims_codomain)
     a_merged = sectormergesort(a_reshaped)
-    a_padded = pad_to_canonical_duals(a_merged)
-    return FusedGradedMatrix(a_padded)
+    return FusedGradedMatrix(insert_missing_sectors(a_merged))
 end
 
 # ========================  AbelianGradedArray unmatricize  ========================

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -152,19 +152,22 @@ end
 # `sectormergesort`); repeated sectors on one axis would be silently collapsed
 # by the dict-based multiplicity lookup below, and the sorted-insertion logic
 # (via `sort!(vcat(...))`) would reorder blocks unexpectedly otherwise.
-function insert_missing_sectors(a::AbelianGradedMatrix)
+function insert_missing_sectors end
+
+function check_input(::typeof(insert_missing_sectors), a::AbelianGradedMatrix)
     cod_sects = sectors(axes(a, 1))
     dom_sects = sectors(axes(a, 2))
     (issorted(cod_sects) && allunique(cod_sects)) ||
-        throw(
-        ArgumentError(
-            "insert_missing_sectors requires sorted, unique codomain sectors"
-        )
-    )
+        throw(ArgumentError("codomain sectors must be sorted and unique"))
     (issorted(dual.(dom_sects)) && allunique(dom_sects)) ||
-        throw(
-        ArgumentError("insert_missing_sectors requires sorted, unique domain sectors")
-    )
+        throw(ArgumentError("domain sectors must have sorted, unique duals"))
+    return nothing
+end
+
+function insert_missing_sectors(a::AbelianGradedMatrix)
+    check_input(insert_missing_sectors, a)
+    cod_sects = sectors(axes(a, 1))
+    dom_sects = sectors(axes(a, 2))
     cod_sects == dual.(dom_sects) && return a
 
     canonical = sort!(unique!(vcat(collect(cod_sects), dual.(collect(dom_sects)))))
@@ -275,7 +278,10 @@ end
 #
 # Sectors of `m` dropped from the target must have multiplicity 0 on both
 # axes, otherwise silent data loss would occur.
-function delete_missing_sectors(
+function delete_missing_sectors end
+
+function check_input(
+        ::typeof(delete_missing_sectors),
         m::AbstractGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo
     )
     cod_m = sectors(axes(m, 1))
@@ -294,23 +300,30 @@ function delete_missing_sectors(
     cod_m == dual.(dom_m) ||
         throw(ArgumentError("m must have canonical-dual codomain/domain axes"))
 
+    # Sectors of `m` absent from either target axis must have multiplicity 0
+    # on at least one side (empty block → safe to drop, no data loss).
     cod_t_set = Set(cod_t)
     dom_t_set = Set(dom_t)
     cod_m_lens = datalengths(axes(m, 1))
     dom_m_lens = datalengths(axes(m, 2))
     for (i, s) in pairs(cod_m)
         (s ∈ cod_t_set && dual(s) ∈ dom_t_set) && continue
-        # Safe to drop only if the block is empty (either axis has multiplicity 0).
         (iszero(cod_m_lens[i]) || iszero(dom_m_lens[i])) || throw(
             ArgumentError(
                 "sector $s would be dropped by the target axes but has non-zero multiplicity in m"
             )
         )
     end
+    return nothing
+end
 
+function delete_missing_sectors(
+        m::AbstractGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo
+    )
+    check_input(delete_missing_sectors, m, cod_ax, dom_ax)
     a = FI.zero!(similar(m, (cod_ax, dom_ax)))
-    cod_pos = Dict(s => i for (i, s) in pairs(cod_t))
-    dom_pos = Dict(s => j for (j, s) in pairs(dom_t))
+    cod_pos = Dict(s => i for (i, s) in pairs(sectors(cod_ax)))
+    dom_pos = Dict(s => j for (j, s) in pairs(sectors(dom_ax)))
     for I in eachblockstoredindex(m)
         aI = view(m, I)
         s_cod, s_dom = sectoraxes(aI)

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -174,7 +174,7 @@ function insert_missing_sectors(a::AbelianGradedMatrix)
     dom′ = gradedrange([dual(s) => get(dom_lens, dual(s), 0) for s in canonical])
 
     a′ = FI.zero!(similar(a, (cod′, dom′)))
-    pos = Dict(s => i for (i, s) in enumerate(canonical))
+    pos = Dict(s => i for (i, s) in pairs(canonical))
     for I in eachblockstoredindex(a)
         aI = view(a, I)
         s_cod, s_dom = sectoraxes(aI)
@@ -260,6 +260,68 @@ function TensorAlgebra.unmatricize(
     return a
 end
 
+# ========================  delete_missing_sectors  ========================
+
+# Embed an `AbstractGradedMatrix` in target `(cod_ax, dom_ax)` axes: stored
+# blocks of `m` are re-placed at the corresponding sector position in the
+# target, and sectors of `m` absent from the target are dropped. Target
+# sectors absent from `m` simply become unstored blocks.
+#
+# Each axis (on both `m` and the target) must have sorted, unique sectors,
+# and `m` must have canonical-dual codomain/domain axes
+# (`sectors(cod_m) == dual.(sectors(dom_m))`). The target axes are not
+# required to be canonical duals — `unmatricize` takes the unfused target
+# axes which can have asymmetric sector sets.
+#
+# Sectors of `m` dropped from the target must have multiplicity 0 on both
+# axes, otherwise silent data loss would occur.
+function delete_missing_sectors(
+        m::AbstractGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo
+    )
+    cod_m = sectors(axes(m, 1))
+    dom_m = sectors(axes(m, 2))
+    cod_t = sectors(cod_ax)
+    dom_t = sectors(dom_ax)
+
+    (issorted(cod_m) && allunique(cod_m)) ||
+        throw(ArgumentError("m's codomain sectors must be sorted and unique"))
+    (issorted(dual.(dom_m)) && allunique(dom_m)) ||
+        throw(ArgumentError("m's domain sectors must have sorted, unique duals"))
+    (issorted(cod_t) && allunique(cod_t)) ||
+        throw(ArgumentError("target codomain sectors must be sorted and unique"))
+    (issorted(dual.(dom_t)) && allunique(dom_t)) ||
+        throw(ArgumentError("target domain sectors must have sorted, unique duals"))
+    cod_m == dual.(dom_m) ||
+        throw(ArgumentError("m must have canonical-dual codomain/domain axes"))
+
+    cod_t_set = Set(cod_t)
+    dom_t_set = Set(dom_t)
+    cod_m_lens = datalengths(axes(m, 1))
+    dom_m_lens = datalengths(axes(m, 2))
+    for (i, s) in pairs(cod_m)
+        (s ∈ cod_t_set && dual(s) ∈ dom_t_set) && continue
+        # Safe to drop only if the block is empty (either axis has multiplicity 0).
+        (iszero(cod_m_lens[i]) || iszero(dom_m_lens[i])) || throw(
+            ArgumentError(
+                "sector $s would be dropped by the target axes but has non-zero multiplicity in m"
+            )
+        )
+    end
+
+    a = FI.zero!(similar(m, (cod_ax, dom_ax)))
+    cod_pos = Dict(s => i for (i, s) in pairs(cod_t))
+    dom_pos = Dict(s => j for (j, s) in pairs(dom_t))
+    for I in eachblockstoredindex(m)
+        aI = view(m, I)
+        s_cod, s_dom = sectoraxes(aI)
+        i = get(cod_pos, s_cod, nothing)
+        j = get(dom_pos, s_dom, nothing)
+        (isnothing(i) || isnothing(j)) && continue
+        a[Data(i, j)] = data(aI)
+    end
+    return a
+end
+
 # ========================  SectorFusion FusedGradedMatrix unmatricize  ========================
 
 function TensorAlgebra.unmatricize(
@@ -274,9 +336,9 @@ function TensorAlgebra.unmatricize(
     unfused_axes = matricize_axes(BlockReshapeFusion(), m, codomain_axes, domain_axes)
     merged_cod = sectormergesort(unfused_axes[1])
     merged_dom = sectormergesort(unfused_axes[2])
-    # Build an `AbelianGradedMatrix` directly with those merged axes (sectors
+    # Embed `m` into an `AbelianGradedMatrix` with those merged axes (sectors
     # in `merged_*` but not in `m.sectors` simply land as unstored blocks).
-    m_abelian = AbelianGradedArray(m, merged_cod, merged_dom)
+    m_abelian = delete_missing_sectors(m, merged_cod, merged_dom)
     blockperms = sectorsortperm.(unfused_axes)
     J = map(invblockmergeperm, unfused_axes, blockperms, axes(m_abelian))
     m_split = m_abelian[J...]

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -159,10 +159,9 @@ function pad_to_canonical_duals(a::AbelianGradedMatrix)
     a′ = FI.zero!(similar(a, (cod′, dom′)))
     pos = Dict(s => i for (i, s) in enumerate(canonical))
     for I in eachblockstoredindex(a)
-        i, j = Int.(Tuple(I))
-        new_i = pos[cod_sects[i]]
-        new_j = pos[dual(dom_sects[j])]
-        a′[Data(new_i, new_j)] = data(a[I])
+        aI = view(a, I)
+        s_cod, s_dom = sectoraxes(aI)
+        a′[Data(pos[s_cod], pos[dual(s_dom)])] = data(aI)
     end
     return a′
 end
@@ -215,7 +214,7 @@ function TensorAlgebra.unmatricize(
     return AbelianSectorArray(msectors, mdata)
 end
 
-# ========================  BlockReshapeFusion AbelianGradedArray unmatricize  ========================
+# ========================  BlockReeshapeFusion AbelianGradedArray unmatricize  ========================
 
 function TensorAlgebra.unmatricize(
         ::BlockReshapeFusion, m::AbelianGradedMatrix{T},

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -279,54 +279,57 @@ end
 
 # ========================  delete_missing_sectors  ========================
 
-# Embed an `AbstractGradedMatrix` in target `(cod_ax, dom_ax)` axes: stored
-# blocks of `m` are re-placed at the corresponding sector position in the
-# target, and sectors of `m` absent from the target are dropped. Target
-# sectors absent from `m` simply become unstored blocks.
+# Reverse `insert_missing_sectors`: given a matrix `m` with canonical-dual
+# axes (as produced by `insert_missing_sectors`) and target axes
+# `(cod_ax, dom_ax)` whose allowed-block sectors are a subset of `m`'s, drop
+# `m`'s sectors that are absent from the target. In the canonical matricize
+# → unmatricize round-trip, the dropped sectors are exactly the
+# zero-multiplicity entries `insert_missing_sectors` added, so nothing is
+# actually lost.
 #
 # Each axis (on both `m` and the target) must have sorted, unique sectors,
 # and `m` must have canonical-dual codomain/domain axes
 # (`sectors(cod_m) == dual.(sectors(dom_m))`). The target axes are not
-# required to be canonical duals — `unmatricize` takes the unfused target
-# axes which can have asymmetric sector sets.
+# required to be canonical duals (`unmatricize` takes the unfused target
+# axes, which can have asymmetric sector sets).
 #
-# Sectors of `m` dropped from the target must have multiplicity 0 on both
-# axes, otherwise silent data loss would occur.
+# Preconditions:
+#   - sectors of `m` absent from the target have multiplicity 0 on at least
+#     one side (empty block → safe to drop);
+#   - every allowed block of the target has a corresponding sector in `m`
+#     (otherwise we'd be inventing data out of thin air, which is a user
+#     error — they've passed target axes incompatible with `m`).
 function delete_missing_sectors end
 
 function check_input(
         ::typeof(delete_missing_sectors),
         m::AbstractGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo
     )
-    cod_m = sectors(axes(m, 1))
-    dom_m = sectors(axes(m, 2))
-    cod_t = sectors(cod_ax)
-    dom_t = sectors(dom_ax)
-
-    (issorted(cod_m) && allunique(cod_m)) ||
-        throw(ArgumentError("m's codomain sectors must be sorted and unique"))
-    (issorted(dual.(dom_m)) && allunique(dom_m)) ||
-        throw(ArgumentError("m's domain sectors must have sorted, unique duals"))
-    (issorted(cod_t) && allunique(cod_t)) ||
-        throw(ArgumentError("target codomain sectors must be sorted and unique"))
-    (issorted(dual.(dom_t)) && allunique(dom_t)) ||
-        throw(ArgumentError("target domain sectors must have sorted, unique duals"))
-    cod_m == dual.(dom_m) ||
-        throw(ArgumentError("m must have canonical-dual codomain/domain axes"))
-
-    # Sectors of `m` absent from either target axis must have multiplicity 0
-    # on at least one side (empty block → safe to drop, no data loss).
-    cod_t_set = Set(cod_t)
-    dom_t_set = Set(dom_t)
-    cod_m_lens = datalengths(axes(m, 1))
-    dom_m_lens = datalengths(axes(m, 2))
-    for (i, s) in pairs(cod_m)
-        (s ∈ cod_t_set && dual(s) ∈ dom_t_set) && continue
-        (iszero(cod_m_lens[i]) || iszero(dom_m_lens[i])) || throw(
+    axs = (
+        ("m codomain", sectors(axes(m, 1)), datalengths(axes(m, 1)), sectors(cod_ax)),
+        ("m domain", sectors(axes(m, 2)), datalengths(axes(m, 2)), sectors(dom_ax)),
+    )
+    for (name, m_sects, m_lens, t_sects) in axs
+        # 1. Input (m) and output (target) axes are sorted and unique.
+        (issorted(m_sects) && allunique(m_sects)) ||
+            throw(ArgumentError("$name sectors must be sorted and unique"))
+        (issorted(t_sects) && allunique(t_sects)) ||
+            throw(ArgumentError("target $name sectors must be sorted and unique"))
+        # 2. Target sectors are a subset of `m`'s sectors.
+        issubset(t_sects, m_sects) || throw(
             ArgumentError(
-                "sector $s would be dropped by the target axes but has non-zero multiplicity in m"
+                "target $name sectors $(setdiff(t_sects, m_sects)) are missing from m"
             )
         )
+        # 3. `m` sectors dropped by the target have multiplicity 0.
+        for (i, s) in pairs(m_sects)
+            s ∈ t_sects && continue
+            iszero(m_lens[i]) || throw(
+                ArgumentError(
+                    "$name sector $s would be dropped by the target but has non-zero multiplicity in m"
+                )
+            )
+        end
     end
     return nothing
 end
@@ -335,9 +338,10 @@ function delete_missing_sectors(
         m::AbstractGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo
     )
     check_input(delete_missing_sectors, m, cod_ax, dom_ax)
-    # `zero!` is needed: the target axes can have sectors absent from `m`, so
-    # some allowed blocks of the result never get written by the loop below.
-    a = FI.zero!(similar(m, (cod_ax, dom_ax)))
+    # No `zero!` needed: `check_input` guarantees every allowed-block sector
+    # of the target is present in `m`, so every allocation below is
+    # overwritten by the loop.
+    a = similar(m, (cod_ax, dom_ax))
     cod_pos = Dict(s => i for (i, s) in pairs(sectors(cod_ax)))
     dom_pos = Dict(s => j for (j, s) in pairs(sectors(dom_ax)))
     for I in eachblockstoredindex(m)

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -115,6 +115,10 @@ function TensorAlgebra.matricize(
         style::BlockReshapeFusion, a::AbelianGradedArray{T, N}, ndims_codomain::Val{K}
     ) where {T, N, K}
     ax_2d = matricize_axes(style, a, ndims_codomain)
+    # `similar` allocates every allowed 2D block; the loop below only writes
+    # those coming from stored blocks of `a`. For a sparse input, allowed
+    # destination blocks with no source counterpart stay at their initial
+    # value, so we must explicitly zero them.
     a_2d = FI.zero!(similar(a, ax_2d))
 
     codomain_nblocks = Tuple(blocklength.(axes(a)[1:K]))
@@ -176,7 +180,13 @@ function insert_missing_sectors(a::AbelianGradedMatrix)
     cod′ = gradedrange([s => get(cod_lens, s, 0) for s in canonical])
     dom′ = gradedrange([dual(s) => get(dom_lens, dual(s), 0) for s in canonical])
 
-    a′ = FI.zero!(similar(a, (cod′, dom′)))
+    # No `zero!` needed: every allowed block of `a′` that is non-empty on
+    # both axes corresponds to a sector that exists on both `cod` and `dom`
+    # of `a`, i.e. to a stored block of `a` (assuming `a` is the output of
+    # `sectormergesort`, where all allowed blocks are stored). Blocks coming
+    # purely from padding have multiplicity 0 on one axis — zero-size
+    # allocations with no data to clean up.
+    a′ = similar(a, (cod′, dom′))
     pos = Dict(s => i for (i, s) in pairs(canonical))
     for I in eachblockstoredindex(a)
         aI = view(a, I)
@@ -243,6 +253,10 @@ function TensorAlgebra.unmatricize(
     K = length(codomain_axes)
     N = K + length(domain_axes)
     dest_axes = (codomain_axes..., domain_axes...)
+    # `similar` allocates every allowed N-D block; the loop only writes those
+    # coming from stored 2D blocks of `m`. For a sparse input, allowed
+    # destination blocks with no source counterpart must be explicitly
+    # zeroed.
     a = FI.zero!(similar(m, dest_axes))
 
     cod_cart = CartesianIndices(Tuple(map(blocklength, codomain_axes)))
@@ -321,6 +335,8 @@ function delete_missing_sectors(
         m::AbstractGradedMatrix, cod_ax::GradedOneTo, dom_ax::GradedOneTo
     )
     check_input(delete_missing_sectors, m, cod_ax, dom_ax)
+    # `zero!` is needed: the target axes can have sectors absent from `m`, so
+    # some allowed blocks of the result never get written by the loop below.
     a = FI.zero!(similar(m, (cod_ax, dom_ax)))
     cod_pos = Dict(s => i for (i, s) in pairs(sectors(cod_ax)))
     dom_pos = Dict(s => j for (j, s) in pairs(sectors(dom_ax)))

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -139,6 +139,59 @@ function TensorAlgebra.matricize(
     return a_2d
 end
 
+# ========================  pad_to_canonical_duals  ========================
+
+# Pad an AbelianGradedMatrix so its codomain and domain axes form canonical duals.
+# After sectormergesort, the codomain (non-dual) and domain (dual) axes are sorted
+# but may have different sector sets. This adds zero-multiplicity entries for
+# missing sectors so that `sectors(axis1) == dual.(sectors(axis2))`.
+function pad_to_canonical_duals(a::AbelianGradedMatrix{T}) where {T}
+    ax_cod = axes(a, 1)
+    ax_dom = axes(a, 2)
+
+    cod_sects = sectors(ax_cod)
+    dom_sects = sectors(ax_dom)
+
+    # Fast path: already canonical duals
+    cod_sects == dual.(dom_sects) && return a
+
+    # Compute the union of codomain sectors and dual(domain sectors), all non-dual.
+    # Both inputs are sorted after sectormergesort.
+    cod_nondual = collect(cod_sects)
+    dom_nondual = collect(dual.(dom_sects))
+    all_sects = sort!(unique!([cod_nondual; dom_nondual]))
+
+    # Build padded codomain axis (non-dual): existing datalengths for known sectors,
+    # zero for missing ones.
+    cod_dlens = GradedArrays.datalengths(ax_cod)
+    dom_dlens = GradedArrays.datalengths(ax_dom)
+
+    cod_dict = Dict(zip(cod_sects, cod_dlens))
+    dom_dict = Dict(zip(dom_sects, dom_dlens))
+
+    padded_cod_pairs = [s => get(cod_dict, s, 0) for s in all_sects]
+    padded_dom_pairs = [dual(s) => get(dom_dict, dual(s), 0) for s in all_sects]
+
+    padded_cod = gradedrange(padded_cod_pairs)
+    padded_dom = gradedrange(padded_dom_pairs)
+
+    # Allocate padded matrix with zero-initialized blocks.
+    a_padded = GradedArrays.FI.zero!(similar(a, (padded_cod, padded_dom)))
+
+    # Copy existing blocks. Map old block indices to new block indices via sector lookup.
+    cod_idx = Dict(s => i for (i, s) in enumerate(all_sects))
+    dom_idx = Dict(dual(s) => i for (i, s) in enumerate(all_sects))
+
+    for bI in eachblockstoredindex(a)
+        old_row, old_col = Int.(Tuple(bI))
+        new_row = cod_idx[cod_sects[old_row]]
+        new_col = dom_idx[dom_sects[old_col]]
+        copyto!(data(view(a_padded, Block(new_row, new_col))), data(a[bI]))
+    end
+
+    return a_padded
+end
+
 # ========================  SectorFusion AbelianGradedArray matricize  ========================
 
 function TensorAlgebra.matricize(
@@ -146,7 +199,8 @@ function TensorAlgebra.matricize(
     ) where {K}
     a_reshaped = matricize(BlockReshapeFusion(), a, ndims_codomain)
     a_merged = sectormergesort(a_reshaped)
-    return FusedGradedMatrix(a_merged)
+    a_padded = pad_to_canonical_duals(a_merged)
+    return FusedGradedMatrix(a_padded)
 end
 
 # ========================  AbelianGradedArray unmatricize  ========================
@@ -218,6 +272,34 @@ end
 
 # ========================  SectorFusion FusedGradedMatrix unmatricize  ========================
 
+# Pad a FusedGradedMatrix to have the given codomain and domain axes.
+# Existing blocks are copied; missing sectors get zero-size blocks (0xN or Nx0).
+function _pad_fused(
+        m::FusedGradedMatrix{T},
+        cod_ax::GradedOneTo,
+        dom_ax::GradedOneTo
+    ) where {T}
+    expected_sects = sectors(cod_ax)
+    expected_cod_dlens = datalengths(cod_ax)
+    expected_dom_dlens = datalengths(dom_ax)
+
+    # Fast path: already matches
+    m.sectors == expected_sects && return m
+
+    m_dict = Dict(s => i for (i, s) in enumerate(m.sectors))
+    new_sectors = collect(expected_sects)
+    new_blocks = Matrix{T}[]
+    for (i, s) in enumerate(expected_sects)
+        j = get(m_dict, s, nothing)
+        if isnothing(j)
+            push!(new_blocks, zeros(T, expected_cod_dlens[i], expected_dom_dlens[i]))
+        else
+            push!(new_blocks, m.blocks[j])
+        end
+    end
+    return FusedGradedMatrix(new_sectors, new_blocks)
+end
+
 function TensorAlgebra.unmatricize(
         ::SectorFusion, m::FusedGradedMatrix,
         codomain_axes::Tuple{Vararg{GradedOneTo}},
@@ -228,8 +310,16 @@ function TensorAlgebra.unmatricize(
         error("Scalar unmatricize not yet supported for FusedGradedMatrix")
     end
 
+    # Compute the unfused 2D axes that the N-D blocked axes produce.
     unfused_axes = matricize_axes(BlockReshapeFusion(), m, codomain_axes, domain_axes)
-    m_abelian = AbelianGradedArray(m)
+    # Merge-sort the unfused axes to get the expected merged axes.
+    expected_cod = sectormergesort(unfused_axes[1])
+    expected_dom = sectormergesort(unfused_axes[2])
+    # Pad m so its axes match the expected merged axes (adds zero-size blocks
+    # for sectors absent from the multiplication result).
+    m_padded = _pad_fused(m, expected_cod, expected_dom)
+
+    m_abelian = AbelianGradedArray(m_padded)
     blockperms = sectorsortperm.(unfused_axes)
     J = map(invblockmergeperm, unfused_axes, blockperms, axes(m_abelian))
     m_split = m_abelian[J...]

--- a/src/gradedoneto.jl
+++ b/src/gradedoneto.jl
@@ -178,13 +178,36 @@ function Base.hash(g::GradedOneTo, h::UInt)
     return hash(g.nondual_sectors, hash(datalengths(g), hash(isdual(g), h)))
 end
 
-# Show. Show dual axes by displaying a `'` on each individual sector rather
-# than as a trailing `'` on the whole range — this matches the form accepted
-# by the `gradedrange` constructor.
+# Show. Factor the `dual` to the outside — `dual(gradedrange([...]))` — rather
+# than decorating each sector, so the printed form is compact and round-trips
+# through the constructor.
 function Base.show(io::IO, g::GradedOneTo)
+    isdual(g) && print(io, "dual(")
     print(io, "gradedrange([")
-    join(io, (sector(ba) => datalength(ba) for ba in eachblockaxis(g)), ", ")
+    join(
+        io,
+        (s => m for (s, m) in zip(g.nondual_sectors, datalengths(g))),
+        ", "
+    )
     print(io, "])")
+    isdual(g) && print(io, ")")
+    return nothing
+end
+
+# Show a "sectors: ..." line between the default AbstractArray summary and the
+# block-separated element listing inherited from AbstractBlockedUnitRange. For
+# dual axes the sectors are shown as `dual.([...])`.
+function Base.show(io::IO, ::MIME"text/plain", g::GradedOneTo)
+    summary(io, g)
+    isempty(g) && return nothing
+    print(io, ":\n  sectors: ")
+    isdual(g) && print(io, "dual.(")
+    print(io, "[")
+    join(io, g.nondual_sectors, ", ")
+    print(io, "]")
+    isdual(g) && print(io, ")")
+    println(io)
+    Base.print_array(io, g)
     return nothing
 end
 

--- a/src/gradedoneto.jl
+++ b/src/gradedoneto.jl
@@ -7,7 +7,7 @@ This is the axis type for `AbelianGradedArray`.
 Stores non-dual `SectorRange` values in `nondual_sectors`, sector lengths, and a single
 `isdual` flag. The `sectors` accessor applies the `isdual` flag on the fly.
 """
-struct GradedOneTo{S <: SectorRange} <: AbstractUnitRange{Int}
+struct GradedOneTo{S <: SectorRange} <: AbstractBlockedUnitRange{Int, Vector{Int}}
     nondual_sectors::Vector{S}
     datalengths::Vector{Int}
     isdual::Bool
@@ -34,9 +34,9 @@ isdual(g::GradedOneTo) = g.isdual
 sectors(g::GradedOneTo) = isdual(g) ? dual.(g.nondual_sectors) : g.nondual_sectors
 sectorlengths(g::GradedOneTo) = length.(sectors(g))
 Base.first(::GradedOneTo) = 1
+BlockArrays.blocklasts(g::GradedOneTo) = cumsum(blocklengths(g))
 BlockArrays.blocklength(g::GradedOneTo) = length(g.nondual_sectors)
 BlockArrays.eachblockaxes1(g::GradedOneTo) = eachblockaxis(g)
-Base.length(g::GradedOneTo) = sum(blocklengths(g); init = 0)
 
 # sectortype, SymmetryStyle
 sectortype(::Type{GradedOneTo{S}}) where {S} = S

--- a/src/gradedoneto.jl
+++ b/src/gradedoneto.jl
@@ -178,17 +178,13 @@ function Base.hash(g::GradedOneTo, h::UInt)
     return hash(g.nondual_sectors, hash(datalengths(g), hash(isdual(g), h)))
 end
 
-# Show
+# Show. Show dual axes by displaying a `'` on each individual sector rather
+# than as a trailing `'` on the whole range — this matches the form accepted
+# by the `gradedrange` constructor.
 function Base.show(io::IO, g::GradedOneTo)
-    print(io, "GradedOneTo(")
-    print(io, "[")
-    for (i, ba) in enumerate(eachblockaxis(g))
-        i > 1 && print(io, ", ")
-        show(io, nondual(sector(ba)))
-        print(io, " => ", datalength(ba))
-    end
+    print(io, "gradedrange([")
+    join(io, (sector(ba) => datalength(ba) for ba in eachblockaxis(g)), ", ")
     print(io, "])")
-    isdual(g) && print(io, "'")
     return nothing
 end
 

--- a/src/gradedoneto.jl
+++ b/src/gradedoneto.jl
@@ -182,10 +182,10 @@ end
 function Base.show(io::IO, g::GradedOneTo)
     print(io, "GradedOneTo(")
     print(io, "[")
-    for (i, (s, m)) in enumerate(zip(sectors(g), datalengths(g)))
+    for (i, ba) in enumerate(eachblockaxis(g))
         i > 1 && print(io, ", ")
-        show(io, label(s))
-        print(io, " => ", m)
+        show(io, nondual(sector(ba)))
+        print(io, " => ", datalength(ba))
     end
     print(io, "])")
     isdual(g) && print(io, "'")

--- a/src/sectoroneto.jl
+++ b/src/sectoroneto.jl
@@ -104,7 +104,7 @@ end
 
 function Base.show(io::IO, r::SectorOneTo)
     print(io, "SectorOneTo(")
-    show(io, label(sector(r)))
+    show(io, sector(r))
     print(io, ", ", datalength(r))
     print(io, ")")
     isdual(r) && print(io, "'")

--- a/src/sectoroneto.jl
+++ b/src/sectoroneto.jl
@@ -102,11 +102,15 @@ end
 
 # ========================  Show  ========================
 
+# Duality is carried on the stored `SectorRange` and is already shown by its
+# own `show` method (via a trailing `'`), so we don't add another `'` on the
+# outer `SectorOneTo(...)`.
 function Base.show(io::IO, r::SectorOneTo)
     print(io, "SectorOneTo(")
     show(io, sector(r))
     print(io, ", ", datalength(r))
     print(io, ")")
-    isdual(r) && print(io, "'")
     return nothing
 end
+
+Base.adjoint(r::SectorOneTo) = dual(r)

--- a/src/sectoroneto.jl
+++ b/src/sectoroneto.jl
@@ -102,14 +102,15 @@ end
 
 # ========================  Show  ========================
 
-# Duality is carried on the stored `SectorRange` and is already shown by its
-# own `show` method (via a trailing `'`), so we don't add another `'` on the
-# outer `SectorOneTo(...)`.
+# Factor the `dual` to the outside — `dual(SectorOneTo(sector, n))` — rather
+# than decorating the inner sector, mirroring the `GradedOneTo` convention.
 function Base.show(io::IO, r::SectorOneTo)
+    isdual(r) && print(io, "dual(")
     print(io, "SectorOneTo(")
-    show(io, sector(r))
+    show(io, nondual(sector(r)))
     print(io, ", ", datalength(r))
     print(io, ")")
+    isdual(r) && print(io, ")")
     return nothing
 end
 

--- a/src/sectorrange.jl
+++ b/src/sectorrange.jl
@@ -45,12 +45,20 @@ Base.first(r::SectorRange) = first(Base.OneTo(r))
 Base.last(r::SectorRange) = last(Base.OneTo(r))
 
 function Base.show(io::IO, r::SectorRange{I}) where {I}
+    # Print duals as `dual(...)` rather than using a trailing `'`: Julia already
+    # uses `'` for adjoint of ranges (`(1:4)'` returns a 1×N adjoint matrix), so
+    # reusing `'` here is ambiguous.
+    if isdual(r)
+        print(io, "dual(")
+        show(io, nondual(r))
+        print(io, ")")
+        return nothing
+    end
     show(io, typeof(r))
     print(io, '(')
     l = sector_label(r)
     isnothing(l) || show(io, l)
     print(io, ')')
-    isdual(r) && print(io, "'")
     return nothing
 end
 

--- a/src/sectorrange.jl
+++ b/src/sectorrange.jl
@@ -92,6 +92,7 @@ dual(c::TKS.Sector) = TKS.dual(c)
 dual(r1::SectorRange) = typeof(r1)(r1.label, !isdual(r1))
 flip(r1::SectorRange) = typeof(r1)(dual(r1.label), !isdual(r1))
 flip_dual(r::SectorRange) = isdual(r) ? flip(r) : r
+nondual(r::SectorRange) = isdual(r) ? dual(r) : r
 
 fermionparity(c::SectorRange) = TKS.fermionparity(c.label)
 twist(c::SectorRange) = TKS.twist(c.label)

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -167,7 +167,7 @@ function TensorAlgebra.permutedimsopadd!(
         y::AbelianGradedArray{<:Any, N}, op, x::AbelianGradedArray{<:Any, N}, perm,
         α::Number, β::Number
     ) where {N}
-    iszero(β) || scale!(y, β)
+    scale!(y, β)
     for bI in eachblockstoredindex(x)
         b = Tuple(bI)
         b_dest = Block(ntuple(i -> b[perm[i]], N))

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -167,6 +167,15 @@ function TensorAlgebra.permutedimsopadd!(
         y::AbstractGradedArray{<:Any, N}, op, x::AbstractGradedArray{<:Any, N}, perm,
         α::Number, β::Number
     ) where {N}
+    # `scale!(y, 0)` doesn't reliably zero `y`: if any block of `y` holds
+    # `NaN`/`Inf` (uninitialized memory from `undef` allocation or a stale
+    # garbage value), `NaN * 0 == NaN` keeps it poisoned, and subsequent
+    # `permutedimsopadd!(..., α, one(α))` calls on a block of `y` that
+    # doesn't get visited by the loop below would leak that garbage into the
+    # result. Allocating broadcasts like `3 * a` go through this path (they
+    # call with β == 0 on a fresh `similar`-allocated array); before this
+    # fix they occasionally produced `NaN`s in unstored-block slots. Call
+    # `zero!` explicitly for β == 0 to avoid the NaN-propagation trap.
     iszero(β) ? FI.zero!(y) : scale!(y, β)
     for bI in eachblockstoredindex(x)
         b = Tuple(bI)

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -164,7 +164,7 @@ function TensorAlgebra.permutedimsopadd!(
 end
 
 function TensorAlgebra.permutedimsopadd!(
-        y::AbelianGradedArray{<:Any, N}, op, x::AbelianGradedArray{<:Any, N}, perm,
+        y::AbstractGradedArray{<:Any, N}, op, x::AbstractGradedArray{<:Any, N}, perm,
         α::Number, β::Number
     ) where {N}
     scale!(y, β)

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -167,7 +167,11 @@ function TensorAlgebra.permutedimsopadd!(
         y::AbstractGradedArray{<:Any, N}, op, x::AbstractGradedArray{<:Any, N}, perm,
         α::Number, β::Number
     ) where {N}
-    scale!(y, β)
+    if iszero(β)
+        FI.zero!(y)
+    else
+        scale!(y, β)
+    end
     for bI in eachblockstoredindex(x)
         b = Tuple(bI)
         b_dest = Block(ntuple(i -> b[perm[i]], N))

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -167,17 +167,13 @@ function TensorAlgebra.permutedimsopadd!(
         y::AbstractGradedArray{<:Any, N}, op, x::AbstractGradedArray{<:Any, N}, perm,
         α::Number, β::Number
     ) where {N}
-    if iszero(β)
-        FI.zero!(y)
-    else
-        scale!(y, β)
-    end
+    iszero(β) ? FI.zero!(y) : scale!(y, β)
     for bI in eachblockstoredindex(x)
         b = Tuple(bI)
         b_dest = Block(ntuple(i -> b[perm[i]], N))
         y_b = view(y, Tuple(b_dest)...)
         x_b = x[bI]
-        TensorAlgebra.permutedimsopadd!(y_b, op, x_b, perm, α, true)
+        TensorAlgebra.permutedimsopadd!(y_b, op, x_b, perm, α, one(α))
     end
     return y
 end

--- a/test/test_abelianarray.jl
+++ b/test/test_abelianarray.jl
@@ -3,6 +3,7 @@ using BlockSparseArrays: eachblockstoredindex
 using GradedArrays: GradedArrays, AbelianGradedArray, AbelianSectorArray,
     AbstractGradedArray, FusedGradedMatrix, GradedOneTo, SU2, SectorRange, U1, data,
     datalengths, dual, gradedrange, isdual, sectoraxes, sectors, sectortype
+using LinearAlgebra: LinearAlgebra
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @test_throws, @testset
 
@@ -220,6 +221,47 @@ end
     @test m isa FusedGradedMatrix{Float64}
     @test data(m[Block(1, 1)]) == [1.0 2.0; 3.0 4.0]
     @test data(m[Block(2, 2)]) == ones(3, 3)
+
+    # Non-abelian (SU2): the codomain block lengths pick up the irrep
+    # dimension `2j + 1`, so `Block(k, k)` has size
+    # `(sectorlength × datalength)^2`.
+    m_su2 = FusedGradedMatrix(
+        [
+            SU2(0) => [1.0;;],
+            SU2(1 // 2) => [1.0 2.0; 3.0 4.0],
+            SU2(1) => Matrix{Float64}(LinearAlgebra.I, 3, 3),
+        ]
+    )
+    @test m_su2 isa FusedGradedMatrix{Float64, Matrix{Float64}, SU2}
+    @test m_su2.sectors == [SU2(0), SU2(1 // 2), SU2(1)]
+    @test data(m_su2[Block(1, 1)]) == [1.0;;]
+    @test data(m_su2[Block(2, 2)]) == [1.0 2.0; 3.0 4.0]
+    # Block(2, 2) lives in SU2(1/2), which has dim 2 → 4×4 in dense view.
+    @test size(m_su2[Block(2, 2)]) == (4, 4)
+end
+
+@testset "FusedGradedMatrix * FusedGradedMatrix" begin
+    @testset "U1 (abelian)" begin
+        a = FusedGradedMatrix([U1(0) => [2.0;;], U1(1) => [1.0 2.0; 3.0 4.0]])
+        b = FusedGradedMatrix([U1(0) => [3.0;;], U1(1) => [0.0 1.0; 1.0 0.0]])
+        c = a * b
+        @test c.sectors == [U1(0), U1(1)]
+        @test data(c[Block(1, 1)]) == [6.0;;]
+        @test data(c[Block(2, 2)]) == [1.0 2.0; 3.0 4.0] * [0.0 1.0; 1.0 0.0]
+    end
+    @testset "SU2 (non-abelian)" begin
+        a = FusedGradedMatrix([SU2(0) => [2.0;;], SU2(1 // 2) => [1.0 2.0; 3.0 4.0]])
+        b = FusedGradedMatrix([SU2(0) => [3.0;;], SU2(1 // 2) => [0.0 1.0; 1.0 0.0]])
+        c = a * b
+        @test c.sectors == [SU2(0), SU2(1 // 2)]
+        @test data(c[Block(1, 1)]) == [6.0;;]
+        @test data(c[Block(2, 2)]) == [1.0 2.0; 3.0 4.0] * [0.0 1.0; 1.0 0.0]
+    end
+    @testset "mismatched sectors throws" begin
+        a = FusedGradedMatrix([U1(0) => [2.0;;], U1(1) => [1.0 2.0; 3.0 4.0]])
+        b = FusedGradedMatrix([U1(0) => [3.0;;]])
+        @test_throws DimensionMismatch a * b
+    end
 end
 
 @testset "FusedGradedMatrix undef constructor" begin

--- a/test/test_abelianarray.jl
+++ b/test/test_abelianarray.jl
@@ -165,7 +165,8 @@ using Test: @test, @test_throws, @testset
         a = AbelianGradedArray{Float64}(undef, g1, g2)
         a[Block(1, 1)] = ones(2, 1)
         s = sprint(show, MIME("text/plain"), a)
-        @test occursin("AbelianGradedArray", s)
+        # Uses the `AbelianGradedMatrix` alias for 2D arrays.
+        @test occursin("AbelianGradedMatrix", s)
         @test occursin("2×2-blocked", s)
         @test occursin("5×3", s)
         @test occursin("2 stored block", s)

--- a/test/test_abelianarray.jl
+++ b/test/test_abelianarray.jl
@@ -214,6 +214,13 @@ using Test: @test, @test_throws, @testset
     end
 end
 
+@testset "FusedGradedMatrix Pair constructor" begin
+    m = FusedGradedMatrix([U1(0) => [1.0 2.0; 3.0 4.0], U1(1) => ones(3, 3)])
+    @test m isa FusedGradedMatrix{Float64}
+    @test data(m[Block(1, 1)]) == [1.0 2.0; 3.0 4.0]
+    @test data(m[Block(2, 2)]) == ones(3, 3)
+end
+
 @testset "FusedGradedMatrix undef constructor" begin
     sectors = [U1(0), U1(1)]
     cod_bls = [2, 3]

--- a/test/test_gradedoneto.jl
+++ b/test/test_gradedoneto.jl
@@ -118,14 +118,17 @@ using Test: @test, @test_throws, @testset
     @testset "show" begin
         g = gradedrange([U1(0) => 2, U1(1) => 3])
         str = sprint(show, g)
-        @test contains(str, "GradedOneTo")
+        @test contains(str, "gradedrange")
         @test contains(str, "=> 2")
         @test contains(str, "=> 3")
-        @test !endswith(str, "'")
+        @test !contains(str, "'")
 
+        # Dual axes show `'` on each individual sector, not as a trailing `'`.
         gd = g'
         strd = sprint(show, gd)
-        @test endswith(strd, "'")
+        @test !endswith(strd, "'")
+        @test contains(strd, "U1(0)' => 2")
+        @test contains(strd, "U1(1)' => 3")
     end
 
     @testset "repeated sectors allowed" begin

--- a/test/test_gradedoneto.jl
+++ b/test/test_gradedoneto.jl
@@ -122,13 +122,14 @@ using Test: @test, @test_throws, @testset
         @test contains(str, "=> 2")
         @test contains(str, "=> 3")
         @test !contains(str, "'")
+        @test !contains(str, "dual")
 
-        # Dual axes show `'` on each individual sector, not as a trailing `'`.
+        # Dual axes factor the `dual` to the outside.
         gd = g'
         strd = sprint(show, gd)
         @test !endswith(strd, "'")
-        @test contains(strd, "U1(0)' => 2")
-        @test contains(strd, "U1(1)' => 3")
+        @test startswith(strd, "dual(gradedrange(")
+        @test endswith(strd, "))")
     end
 
     @testset "repeated sectors allowed" begin

--- a/test/test_sectoroneto.jl
+++ b/test/test_sectoroneto.jl
@@ -116,10 +116,13 @@ using Test: @test, @testset
         str = sprint(show, si)
         @test contains(str, "SectorOneTo")
         @test contains(str, "3")
+        @test !contains(str, "'")
 
+        # Duality shows on the inner sector, not as a trailing `'` on the range.
         sid = SectorOneTo(U1(1)', 3)
         strd = sprint(show, sid)
-        @test endswith(strd, "'")
+        @test contains(strd, "U1(1)'")
+        @test !endswith(strd, "'")
     end
 
     @testset "dual sectors accessor for collection interface" begin

--- a/test/test_sectoroneto.jl
+++ b/test/test_sectoroneto.jl
@@ -117,12 +117,14 @@ using Test: @test, @testset
         @test contains(str, "SectorOneTo")
         @test contains(str, "3")
         @test !contains(str, "'")
+        @test !contains(str, "dual")
 
-        # Duality shows on the inner sector, not as a trailing `'` on the range.
+        # Duality is factored to the outside: `dual(SectorOneTo(...))`.
         sid = SectorOneTo(U1(1)', 3)
         strd = sprint(show, sid)
-        @test contains(strd, "U1(1)'")
-        @test !endswith(strd, "'")
+        @test startswith(strd, "dual(SectorOneTo(")
+        @test endswith(strd, "))")
+        @test !contains(strd, "'")
     end
 
     @testset "dual sectors accessor for collection interface" begin

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -41,18 +41,20 @@ end
     @test g1 isa GradedOneTo
 
     @test sprint(show, g1) ==
-        "GradedOneTo([$U1(0) => 2, $U1(1) => 3, $U1(2) => 2])"
+        "gradedrange([$U1(0) => 2, $U1(1) => 3, $U1(2) => 2])"
 
+    # Duality is shown on each individual sector so the printed form
+    # matches a valid `gradedrange` constructor call.
     g1d = dual(g1)
     @test sprint(show, g1d) ==
-        "GradedOneTo([$U1(0) => 2, $U1(1) => 3, $U1(2) => 2])'"
+        "gradedrange([$U1(0)' => 2, $U1(1)' => 3, $U1(2)' => 2])"
 end
 
 @testset "GradedOneTo show uses compact sector format" begin
     g = gradedrange([U1(0) => 2, U1(1) => 3])
     s = sprint(show, g)
-    @test s == "GradedOneTo([$U1(0) => 2, $U1(1) => 3])"
-    @test sprint(show, dual(g)) == "GradedOneTo([$U1(0) => 2, $U1(1) => 3])'"
+    @test s == "gradedrange([$U1(0) => 2, $U1(1) => 3])"
+    @test sprint(show, dual(g)) == "gradedrange([$U1(0)' => 2, $U1(1)' => 3])"
     @test !occursin("Irrep", s)
 end
 
@@ -98,7 +100,7 @@ end
     a[Block(2, 2)] = [5.0 6.0; 7.0 8.0]
 
     s = sprint(show, MIME("text/plain"), a)
-    @test occursin("AbelianGradedArray", s)
+    @test occursin("AbelianGradedMatrix", s)
     # Unstored blocks show as dots
     @test occursin("⋅", s)
     # Block separators

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -43,18 +43,20 @@ end
     @test sprint(show, g1) ==
         "gradedrange([$U1(0) => 2, $U1(1) => 3, $U1(2) => 2])"
 
-    # Duality is shown on each individual sector so the printed form
-    # matches a valid `gradedrange` constructor call.
+    # Duality is factored to the outside as `dual(gradedrange([...]))` rather
+    # than decorated on each sector; we don't reuse `'` because Julia already
+    # uses `'` for range adjoints.
     g1d = dual(g1)
     @test sprint(show, g1d) ==
-        "gradedrange([$U1(0)' => 2, $U1(1)' => 3, $U1(2)' => 2])"
+        "dual(gradedrange([$U1(0) => 2, $U1(1) => 3, $U1(2) => 2]))"
 end
 
 @testset "GradedOneTo show uses compact sector format" begin
     g = gradedrange([U1(0) => 2, U1(1) => 3])
     s = sprint(show, g)
     @test s == "gradedrange([$U1(0) => 2, $U1(1) => 3])"
-    @test sprint(show, dual(g)) == "gradedrange([$U1(0)' => 2, $U1(1)' => 3])"
+    @test sprint(show, dual(g)) ==
+        "dual(gradedrange([$U1(0) => 2, $U1(1) => 3]))"
     @test !occursin("Irrep", s)
 end
 

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1,5 +1,7 @@
-using GradedArrays: GradedArrays, AbelianSectorArray, Fib, FusedGradedMatrix, GradedOneTo,
-    Ising, O2, SU2, SectorMatrix, SectorOneTo, TrivialSector, U1, dual, gradedrange
+using BlockArrays: Block
+using GradedArrays: GradedArrays, AbelianGradedArray, AbelianSectorArray, Fib,
+    FusedGradedMatrix, GradedOneTo, Ising, O2, SU2, SectorMatrix, SectorOneTo,
+    TrivialSector, U1, dual, gradedrange
 using KroneckerArrays: ×
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @testset
@@ -87,4 +89,39 @@ end
     @test occursin("⊗", s_plain)
     @test occursin("SectorMatrix", s_plain)
     @test occursin("U1(1)", s_plain)
+end
+
+@testset "AbelianGradedArray text/plain display" begin
+    g = gradedrange([U1(0) => 2, U1(1) => 2])
+    a = zeros(Float64, g, dual(g))
+    a[Block(1, 1)] = [1.0 2.0; 3.0 4.0]
+    a[Block(2, 2)] = [5.0 6.0; 7.0 8.0]
+
+    s = sprint(show, MIME("text/plain"), a)
+    @test occursin("AbelianGradedArray", s)
+    # Unstored blocks show as dots
+    @test occursin("⋅", s)
+    # Block separators
+    @test occursin("│", s)
+    @test occursin("─", s)
+    @test occursin("┼", s)
+    # Stored values are present
+    @test occursin("1.0", s)
+    @test occursin("8.0", s)
+end
+
+@testset "FusedGradedMatrix text/plain display" begin
+    m = FusedGradedMatrix([U1(0), U1(1)], [[1.0 2.0; 3.0 4.0], [5.0 6.0; 7.0 8.0]])
+
+    s = sprint(show, MIME("text/plain"), m)
+    @test occursin("FusedGradedMatrix", s)
+    # Unstored blocks show as dots
+    @test occursin("⋅", s)
+    # Block separators
+    @test occursin("│", s)
+    @test occursin("─", s)
+    @test occursin("┼", s)
+    # Stored values are present
+    @test occursin("1.0", s)
+    @test occursin("8.0", s)
 end

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1,5 +1,5 @@
-using GradedArrays: GradedArrays, Fib, FusedGradedMatrix, GradedOneTo, Ising, O2, SU2,
-    SectorOneTo, TrivialSector, U1, dual, gradedrange
+using GradedArrays: GradedArrays, AbelianSectorArray, Fib, FusedGradedMatrix, GradedOneTo,
+    Ising, O2, SU2, SectorMatrix, SectorOneTo, TrivialSector, U1, dual, gradedrange
 using KroneckerArrays: ×
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @testset
@@ -66,4 +66,25 @@ end
     s = sprint(show, r)
     @test occursin("$U1", s)
     @test !occursin("Irrep", s)
+end
+
+@testset "AbelianSectorArray display shows Kronecker structure" begin
+    sa = AbelianSectorArray((U1(0), dual(U1(1))), [1.0 2.0; 3.0 4.0])
+    s = sprint(show, sa)
+    @test occursin("⊗", s)
+
+    s_plain = sprint(show, MIME("text/plain"), sa)
+    @test occursin("⊗", s_plain)
+    @test occursin("AbelianSectorMatrix", s_plain)
+end
+
+@testset "SectorMatrix display shows Kronecker structure" begin
+    sm = SectorMatrix(U1(1), [1.0 2.0; 3.0 4.0])
+    s = sprint(show, sm)
+    @test occursin("⊗", s)
+
+    s_plain = sprint(show, MIME("text/plain"), sm)
+    @test occursin("⊗", s_plain)
+    @test occursin("SectorMatrix", s_plain)
+    @test occursin("U1(1)", s_plain)
 end

--- a/test/test_show.jl
+++ b/test/test_show.jl
@@ -1,5 +1,5 @@
-using GradedArrays:
-    GradedArrays, Fib, GradedOneTo, Ising, O2, SU2, TrivialSector, U1, dual, gradedrange
+using GradedArrays: GradedArrays, Fib, FusedGradedMatrix, GradedOneTo, Ising, O2, SU2,
+    SectorOneTo, TrivialSector, U1, dual, gradedrange
 using KroneckerArrays: ×
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @testset
@@ -38,11 +38,32 @@ end
     g1 = gradedrange([x => 2, y => 3, z => 2])
     @test g1 isa GradedOneTo
 
-    lx = repr(TKS.U1Irrep(0))
-    ly = repr(TKS.U1Irrep(1))
-    lz = repr(TKS.U1Irrep(2))
-    @test sprint(show, g1) == "GradedOneTo([$lx => 2, $ly => 3, $lz => 2])"
+    @test sprint(show, g1) ==
+        "GradedOneTo([$U1(0) => 2, $U1(1) => 3, $U1(2) => 2])"
 
     g1d = dual(g1)
-    @test sprint(show, g1d) == "GradedOneTo([$lx => 2, $ly => 3, $lz => 2])'"
+    @test sprint(show, g1d) ==
+        "GradedOneTo([$U1(0) => 2, $U1(1) => 3, $U1(2) => 2])'"
+end
+
+@testset "GradedOneTo show uses compact sector format" begin
+    g = gradedrange([U1(0) => 2, U1(1) => 3])
+    s = sprint(show, g)
+    @test s == "GradedOneTo([$U1(0) => 2, $U1(1) => 3])"
+    @test sprint(show, dual(g)) == "GradedOneTo([$U1(0) => 2, $U1(1) => 3])'"
+    @test !occursin("Irrep", s)
+end
+
+@testset "FusedGradedMatrix show uses compact sector format" begin
+    m = FusedGradedMatrix([U1(0), U1(1)], [ones(2, 2), ones(3, 3)])
+    s = sprint(show, MIME("text/plain"), m)
+    @test occursin("$U1", s)
+    @test !occursin("Irrep", s)
+end
+
+@testset "SectorOneTo show uses compact sector format" begin
+    r = SectorOneTo(U1(1), 3)
+    s = sprint(show, r)
+    @test occursin("$U1", s)
+    @test !occursin("Irrep", s)
 end

--- a/test/test_tensoralgebra.jl
+++ b/test/test_tensoralgebra.jl
@@ -343,3 +343,21 @@ end
     @test all(iszero, data(c[Block(1, 1)]))
     @test all(iszero, data(c[Block(2, 2)]))
 end
+
+@testset "FusedGradedMatrix broadcasting" begin
+    m = FusedGradedMatrix([U1(0), U1(1)], [[1.0 2.0; 3.0 4.0], [5.0 0.0; 0.0 6.0]])
+
+    m2 = 3 * m
+    @test data(m2[Block(1, 1)]) == [3.0 6.0; 9.0 12.0]
+    @test data(m2[Block(2, 2)]) == [15.0 0.0; 0.0 18.0]
+
+    n = FusedGradedMatrix([U1(0), U1(1)], [ones(2, 2), ones(2, 2)])
+    s = m + n
+    @test data(s[Block(1, 1)]) == [2.0 3.0; 4.0 5.0]
+    @test data(s[Block(2, 2)]) == [6.0 1.0; 1.0 7.0]
+
+    c = similar(m, Float64)
+    c .= 3 .* m .+ 2 .* n
+    @test data(c[Block(1, 1)]) == [5.0 8.0; 11.0 14.0]
+    @test data(c[Block(2, 2)]) == [17.0 2.0; 2.0 20.0]
+end

--- a/test/test_tensoralgebra.jl
+++ b/test/test_tensoralgebra.jl
@@ -320,3 +320,26 @@ end
     result_dense, _ = contract(a_dense, (1, -1, 2, -2), b_dense, (2, -3, 1, -4))
     @test size(result) == size(result_dense)
 end
+
+@testset "scale! with β=0 zeros uninitialized blocks" begin
+    g = gradedrange([U1(0) => 2, U1(1) => 3])
+    a = AbelianGradedArray{Float64}(undef, g, dual(g))
+    GradedArrays.scale!(a, false)
+    @test all(iszero, data(a[Block(1, 1)]))
+    @test all(iszero, data(a[Block(2, 2)]))
+end
+
+@testset "allocating broadcast produces correct results" begin
+    g = gradedrange([U1(0) => 2, U1(1) => 3])
+    a = zeros(Float64, (g, dual(g)))
+    a[Block(1, 1)] = [1.0 0.0; 0.0 1.0]
+    a[Block(2, 2)] = [1.0 0.0 0.0; 0.0 1.0 0.0; 0.0 0.0 1.0]
+
+    b = 3 .* a
+    @test data(b[Block(1, 1)]) == [3.0 0.0; 0.0 3.0]
+    @test data(b[Block(2, 2)]) == [3.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 3.0]
+
+    c = a - a
+    @test all(iszero, data(c[Block(1, 1)]))
+    @test all(iszero, data(c[Block(2, 2)]))
+end

--- a/test/test_tensoralgebra.jl
+++ b/test/test_tensoralgebra.jl
@@ -216,7 +216,7 @@ end
 @testset "matricize 3D AbelianGradedArray and unmatricize round-trip" begin
     # 3D case where the merged codomain (tensor product of two `r`s) has
     # sectors absent from the dual domain — this exercises
-    # `pad_to_canonical_duals` (codomain has U1(2), domain has only U1(0)
+    # `insert_missing_sectors` (codomain has U1(2), domain has only U1(0)
     # and U1(1)).
     r = gradedrange([U1(0) => 1, U1(1) => 2])
     a = zeros(Float64, (r, r, dual(r)))

--- a/test/test_tensoralgebra.jl
+++ b/test/test_tensoralgebra.jl
@@ -213,6 +213,30 @@ end
     @test data(fsm[Block(3, 3)]) ≈ 2 * ones(1, 1)
 end
 
+@testset "matricize 3D AbelianGradedArray and unmatricize round-trip" begin
+    # 3D case where the merged codomain (tensor product of two `r`s) has
+    # sectors absent from the dual domain — this exercises
+    # `pad_to_canonical_duals` (codomain has U1(2), domain has only U1(0)
+    # and U1(1)).
+    r = gradedrange([U1(0) => 1, U1(1) => 2])
+    a = zeros(Float64, (r, r, dual(r)))
+    a[Block(1, 1, 1)] = fill(1.0, 1, 1, 1)
+    a[Block(1, 2, 2)] = fill(2.0, 1, 2, 2)
+    a[Block(2, 1, 2)] = fill(3.0, 2, 1, 2)
+
+    fsm = matricize(a, (1, 2), (3,))
+    @test fsm isa FusedGradedMatrix{Float64}
+    @test fsm.sectors == [U1(0), U1(1), U1(2)]
+
+    # Round-trip through `unmatricize` recovers the original blocks.
+    a_back = unmatricize(fsm, (r, r), (dual(r),))
+    @test a_back isa AbelianGradedArray
+    @test ndims(a_back) == 3
+    for I in eachblockstoredindex(a)
+        @test data(a[I]) ≈ data(a_back[I])
+    end
+end
+
 @testset "FusedGradedMatrix(::AbelianGradedMatrix) requires canonical fused axes" begin
     row_ax = gradedrange([U1(0) => 2, U1(1) => 3])
     a = AbelianGradedArray{Float64}(undef, row_ax, dual(row_ax))


### PR DESCRIPTION
## Summary

A bundle of fixes, refactors, and display improvements for `AbelianGradedArray` and `FusedGradedMatrix`.

## Bug fixes / correctness

- **Allocating broadcast correctness**: handle `β = 0` in `scale!` and drop the `iszero` guard in `permutedimsopadd!`. Previously `scale!(y, 0)` didn't reliably zero `y` when a block held `NaN`/`Inf` (from `undef` memory), which leaked garbage into unstored-block slots of results from `3 * a` / `a + b`. Annotated with a comment at the call site.
- **FusedGradedMatrix broadcasting**: shared `GradedStyle` (renamed from `AbelianGradedStyle`) and a generic `permutedimsopadd!` path.

## Features

- `FusedGradedMatrix([sector => block, ...])` `Pair` constructor.
- Non-canonical axes support for `matricize` / `unmatricize` (via `insert_missing_sectors` / `delete_missing_sectors`).
- Strict 1-arg `AbelianGradedArray(m::AbstractGradedMatrix)` conversion constructor (works for both `AbelianGradedArray` and `FusedGradedMatrix` input).

## Display

- Compact `SectorRange` display: `U1(0)` instead of `Irrep[U₁](0)`. For duals, factored wrapper `dual(U1(0))` (not `'`, which collides with Julia's range adjoint `(1:4)'`).
- `GradedOneTo` shows as `gradedrange([U1(0) => 2, U1(1) => 3])` compact; dual form factored to `dual(gradedrange([...]))`. `MIME\"text/plain\"` inserts a `sectors: [...]` / `sectors: dual.([...])` line between the blocked summary and the element body.
- `SectorOneTo` shows as `SectorOneTo(U1(0), 2)`; duals factored to the outside as `dual(SectorOneTo(U1(0), 2))`.
- `AbstractSectorArray` prints as the Kronecker structure `sector ⊗ data`.
- `AbelianGradedArray` / `FusedGradedMatrix` text/plain:
  - Summary uses `typeof(a)` so the `Vector`/`Matrix` type aliases render naturally.
  - Colon on the first line; each axis gets its own `Dim d: ...` line; block body follows.
- Block-structured matrix display for graded arrays with `│ ─ ┼` separators and `⋅` for unstored blocks. Generalized to arbitrary rank via `collect(Array(sector(blk)) ⊗ data(blk))` (using `KroneckerArrays.⊗`), so 3D arrays display with `[:, :, k] = ...` slice-by-slice block layout.

## Internals / cleanup

Several suspicious helpers from an earlier PR were flagged and either simplified or removed:

- **`pad_to_canonical_duals` → `insert_missing_sectors`**: renamed to reflect what it actually does (pad each axis with multiplicity-0 entries for sectors missing on that side). Simplified implementation (~50 → ~20 lines) using block views + `sectoraxes` instead of integer round-trips. Preconditions (sorted + unique sectors) routed through `check_input(::typeof(insert_missing_sectors), ...)`.
- **`_pad_fused` removed**: replaced by a generic `delete_missing_sectors(m::AbstractGradedMatrix, cod_ax, dom_ax)` helper in `src/fusion.jl` — the inverse of `insert_missing_sectors`. Per-axis set-operation preconditions (sorted+unique, target ⊆ m, m-only sectors are empty blocks) routed through `check_input`.
- **`_mul_mismatched` removed**: `*` on `FusedGradedMatrix` now requires matching sector lists (the standard matrix-multiplication semantics). Shared the `check_mul_axes`-equivalent logic between `*` and `mul!` via `check_input(::typeof(*), A, B)` / `check_input(::typeof(mul!), C, A, B)` (MatrixAlgebraKit-style).
- **`zero!` audit**: dropped two redundant calls (in `AbelianGradedArray(m)` and `permutedims`) and annotated the remaining ones with invariant comments explaining when they're needed.
- `GradedOneTo <: AbstractBlockedUnitRange` (needs `first` + `blocklasts`).
- Minimal `SparseArraysBase` interface (`eachstoredindex`, `storedvalues`, `isstored`) on `AbelianBlocks` so `blockstoredlength(a) = storedlength(blocks(a))` reflects dict-of-keys storage.
- `nondual(::SectorRange)` helper.
- Package-wide `enumerate` → `pairs` for consistency.

## Test plan

- [x] `Pkg.test(\"GradedArrays\")` — all tests pass, including new tests for:
  - allocating-broadcast correctness (graded and sector arrays)
  - `FusedGradedMatrix` `Pair` constructor (both `U1` and `SU2`)
  - `FusedGradedMatrix * FusedGradedMatrix` for abelian (`U1`) and non-abelian (`SU2`) sectors, plus a `DimensionMismatch` case
  - 3D `matricize` + `unmatricize` round-trip (exercises `insert_missing_sectors` / `delete_missing_sectors` + the new axis-aware `AbelianGradedArray` constructor)
  - block-structured display (separators, dots, type aliases)
  - `GradedOneTo` / `SectorOneTo` / sector printing (new `dual(...)` notation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)