### PR TITLE
CompatHelper: bump compat for SUNRepresentations in [weakdeps] to 0.4, (keep existing compat)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -45,7 +45,7 @@ LinearAlgebra = "1.10"
 MatrixAlgebraKit = "0.6"
 NamedDimsArrays = "0.15"
 Random = "1.10"
-SUNRepresentations = "0.3"
+SUNRepresentations = "0.3, 0.4"
 SparseArraysBase = "0.9"
 SplitApplyCombine = "1.2.3"
 TensorAlgebra = "0.8, 0.9"


### PR DESCRIPTION
This pull request changes the compat entry for the `SUNRepresentations` package from `0.3` to `0.3, 0.4`.
This keeps the compat entries for earlier versions.



Note: I have not tested your package with this new compat entry.
It is your responsibility to make sure that your package tests pass before you merge this pull request.