### PR TITLE
Revenge of the fermion: twist and shout

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -312,6 +312,28 @@ function Base.fill!(a::AbelianGradedArray, v)
 end
 
 # ---------------------------------------------------------------------------
+#  twist!
+# ---------------------------------------------------------------------------
+
+"""
+    twist!(a::AbstractGradedArray, dims) -> a
+
+Scale `data(a)` in place by `prod(twist(sectoraxes(a, i)) for i in dims)`.
+Here, `twist` is defined as `-1` for odd-parity fermionic charges and `+1` otherwise.
+
+This is a no-op unless `BraidingStyle(sectortype(a))` is `Fermionic`.
+
+See also [`contraction_twist!`](@ref).
+"""
+function twist!(a::AbstractGradedArray, dims)
+    TKS.BraidingStyle(sectortype(a)) isa TKS.Fermionic || return a
+    for bI in eachblockstoredindex(a)
+        twist!(view(a, bI), dims)
+    end
+    return a
+end
+
+# ---------------------------------------------------------------------------
 #  Matrix multiplication (block-diagonal)
 # ---------------------------------------------------------------------------
 

--- a/src/abeliansectorarray.jl
+++ b/src/abeliansectorarray.jl
@@ -104,8 +104,14 @@ function Base.permutedims!(y::AbelianSectorArray, x::AbelianSectorArray, perm)
     TensorAlgebra.permutedimsopadd!(y, identity, x, perm, true, false)
     return y
 end
+# Eager fallback for non-bosonic braiding: a lazy view of a fermionic array
+# would skip the permutation phase under scalar indexing.
 function FI.permuteddims(x::AbelianSectorArray, perm)
-    return AbelianSectorArray(permutedims(sector(x), perm), FI.permuteddims(data(x), perm))
+    return if TKS.BraidingStyle(sectortype(x)) isa TKS.Bosonic
+        AbelianSectorArray(permutedims(sector(x), perm), FI.permuteddims(data(x), perm))
+    else
+        permutedims(x, perm)
+    end
 end
 
 # ========================  mul!  ========================

--- a/src/abeliansectorarray.jl
+++ b/src/abeliansectorarray.jl
@@ -141,45 +141,11 @@ end
 
 # ========================  twist!  ========================
 
-"""
-    twist!(a::AbelianSectorArray, dims) -> a
-
-Scale `data(a)` in place by `prod(twist(sectoraxes(a, i)) for i in dims)`,
-where each contribution is `-1` for odd-parity fermionic legs and `+1`
-otherwise. `dims` may be any iterable of axis indices.
-
-This is a no-op unless `BraidingStyle(sectortype(a))` is `Fermionic`.
-
-See also [`contraction_twist!`](@ref).
-"""
 function twist!(a::AbelianSectorArray, dims)
     TKS.BraidingStyle(sectortype(a)) isa TKS.Fermionic || return a
     phase = mapreduce(i -> twist(sectoraxes(a, i)), *, dims; init = 1)
     isone(phase) || (data(a) .*= phase)
     return a
-end
-
-"""
-    contraction_twist!(a::AbelianSectorArray, ndims_codomain::Int) -> a
-
-Apply the matricize/unmatricize codomain-twist convention to `data(a)` in
-place: each *dual* codomain leg among the first `ndims_codomain` axes
-contributes a `twist(sectoraxes(a, i))` factor; non-dual legs contribute
-`+1`. Returns `a`.
-
-This is the unmatricize-side counterpart to the codomain twist applied in
-`matricize(::AbelianSectorArray, ...)`. Together they cancel on open codomain
-legs (twist²) and leave a single twist on contracted legs — the residual
-phase that distinguishes a fermionic contraction from a dense one.
-
-Equivalent to `twist!(a, (i for i in 1:ndims_codomain if isdual(a, i)))`.
-A no-op unless `BraidingStyle(sectortype(a))` is `Fermionic`.
-
-See also [`twist!`](@ref).
-"""
-function contraction_twist!(a::AbelianSectorArray, ndims_codomain::Int)
-    TKS.BraidingStyle(sectortype(a)) isa TKS.Fermionic || return a
-    return twist!(a, (i for i in 1:ndims_codomain if isdual(a, i)))
 end
 
 # ========================  Other  ========================

--- a/src/abeliansectorarray.jl
+++ b/src/abeliansectorarray.jl
@@ -139,6 +139,49 @@ function LinearAlgebra.mul!(
     return c
 end
 
+# ========================  twist!  ========================
+
+"""
+    twist!(a::AbelianSectorArray, dims) -> a
+
+Scale `data(a)` in place by `prod(twist(sectoraxes(a, i)) for i in dims)`,
+where each contribution is `-1` for odd-parity fermionic legs and `+1`
+otherwise. `dims` may be any iterable of axis indices.
+
+This is a no-op unless `BraidingStyle(sectortype(a))` is `Fermionic`.
+
+See also [`contraction_twist!`](@ref).
+"""
+function twist!(a::AbelianSectorArray, dims)
+    TKS.BraidingStyle(sectortype(a)) isa TKS.Fermionic || return a
+    phase = mapreduce(i -> twist(sectoraxes(a, i)), *, dims; init = 1)
+    isone(phase) || (data(a) .*= phase)
+    return a
+end
+
+"""
+    contraction_twist!(a::AbelianSectorArray, ndims_codomain::Int) -> a
+
+Apply the matricize/unmatricize codomain-twist convention to `data(a)` in
+place: each *dual* codomain leg among the first `ndims_codomain` axes
+contributes a `twist(sectoraxes(a, i))` factor; non-dual legs contribute
+`+1`. Returns `a`.
+
+This is the unmatricize-side counterpart to the codomain twist applied in
+`matricize(::AbelianSectorArray, ...)`. Together they cancel on open codomain
+legs (twist²) and leave a single twist on contracted legs — the residual
+phase that distinguishes a fermionic contraction from a dense one.
+
+Equivalent to `twist!(a, (i for i in 1:ndims_codomain if isdual(a, i)))`.
+A no-op unless `BraidingStyle(sectortype(a))` is `Fermionic`.
+
+See also [`twist!`](@ref).
+"""
+function contraction_twist!(a::AbelianSectorArray, ndims_codomain::Int)
+    TKS.BraidingStyle(sectortype(a)) isa TKS.Fermionic || return a
+    return twist!(a, (i for i in 1:ndims_codomain if isdual(a, i)))
+end
+
 # ========================  Other  ========================
 
 function KroneckerArrays.:(⊗)(

--- a/src/abeliansectordelta.jl
+++ b/src/abeliansectordelta.jl
@@ -94,20 +94,3 @@ function fermion_permutation_phase(
     mask = map(fermionparity, axes(x))
     return masked_inversion_parity(mask, perm)
 end
-
-function fermion_contraction_phase(
-        x::AbstractSectorDelta{<:Any, N},
-        length_codomain::Int
-    ) where {N}
-    require_unique_fusion(x)
-    BS = TKS.BraidingStyle(sectortype(x))
-    BS isa TKS.Bosonic && return true
-    @assert BS isa TKS.Fermionic "Only symmetric braiding is supported"
-    length_codomain <= ndims(x) ||
-        throw(ArgumentError(lazy"Cannot contract more than ndim legs ($N > $(ndims(x))"))
-
-    parity = mapreduce(⊻, pairs(axes(x))) do (n, ax)
-        return (n <= length_codomain) & isdual(ax) & fermionparity(ax)
-    end
-    return ifelse(parity, -1, 1)
-end

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -217,7 +217,11 @@ function TensorAlgebra.unmatricize(
         src_block = m[bI_src]
         dest_sects = ntuple(d -> sectors(dest_axes[d])[dest_bk[d]], Val(N))
         dest_dims = ntuple(d -> blocklengths(dest_axes[d])[dest_bk[d]], Val(N))
-        dest_block = AbelianSectorArray(dest_sects, reshape(data(src_block), dest_dims))
+        dest_data = reshape(data(src_block), dest_dims)
+        dest_delta = AbelianSectorDelta{T}(dest_sects)
+        phase = fermion_contraction_phase(dest_delta, K)
+        isone(phase) || (dest_data .*= phase)
+        dest_block = AbelianSectorArray(dest_sects, dest_data)
         a[Block(dest_bk...)] = dest_block
     end
 

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -95,17 +95,7 @@ function TensorAlgebra.matricize(
         ::SectorFusion, a::AbelianSectorArray, ndims_codomain::Val{K}
     ) where {K}
     asectors_reshaped = matricize(sector(a), Val(K))
-
-    T = TKS.sectorscalartype(sectortype(a))
-    phase = prod(
-        ntuple(K) do i
-            return ifelse(isdual(a, i), twist(sectoraxes(a, i)), one(T))
-        end
-    )
-
     adata_reshaped = matricize(data(a), Val(K))
-    isone(phase) || (adata_reshaped = phase .* adata_reshaped)
-
     return asectors_reshaped ⊗ adata_reshaped
 end
 
@@ -181,7 +171,7 @@ function TensorAlgebra.unmatricize(
         data.(codomain_axes),
         data.(domain_axes)
     )
-    return contraction_twist!(AbelianSectorArray(msectors, mdata), length(codomain_axes))
+    return AbelianSectorArray(msectors, mdata)
 end
 
 # ========================  BlockReshapeFusion AbelianGradedArray unmatricize  ========================
@@ -212,7 +202,6 @@ function TensorAlgebra.unmatricize(
         dest_sects = ntuple(d -> sectors(dest_axes[d])[dest_bk[d]], Val(N))
         dest_dims = ntuple(d -> blocklengths(dest_axes[d])[dest_bk[d]], Val(N))
         dest_block = AbelianSectorArray(dest_sects, reshape(data(src_block), dest_dims))
-        contraction_twist!(dest_block, K)
         a[Block(dest_bk...)] = dest_block
     end
 

--- a/src/fusion.jl
+++ b/src/fusion.jl
@@ -163,10 +163,8 @@ function TensorAlgebra.unmatricize(
     return AbelianSectorDelta{eltype(m)}((codomain_axes..., domain_axes...))
 end
 
-# Unmatricize a 2D sector array back to an N-D AbelianSectorArray. Decomposes into
-# sector (delta) and data (plain matrix) components, unmatricizes each
-# independently, applies the fermionic contraction phase, and recombines.
-# The codomain/domain axes must be SectorOneTo (carrying multiplicity info).
+# Unmatricize a 2D sector array back to an N-D AbelianSectorArray. The
+# codomain/domain axes must be SectorOneTo (carrying multiplicity info).
 # Works for both AbelianSectorMatrix and SectorMatrix.
 function TensorAlgebra.unmatricize(
         ::SectorFusion, m::AbstractSectorArray{<:Any, 2},
@@ -183,20 +181,16 @@ function TensorAlgebra.unmatricize(
         data.(codomain_axes),
         data.(domain_axes)
     )
-
-    phase = fermion_contraction_phase(msectors, length(codomain_axes))
-    isone(phase) || (mdata = phase .* mdata)
-
-    return AbelianSectorArray(msectors, mdata)
+    return contraction_twist!(AbelianSectorArray(msectors, mdata), length(codomain_axes))
 end
 
 # ========================  BlockReshapeFusion AbelianGradedArray unmatricize  ========================
 
 function TensorAlgebra.unmatricize(
-        ::BlockReshapeFusion, m::AbelianGradedMatrix{T},
+        ::BlockReshapeFusion, m::AbelianGradedMatrix,
         codomain_axes::Tuple{Vararg{GradedOneTo}},
         domain_axes::Tuple{Vararg{GradedOneTo}}
-    ) where {T}
+    )
     K = length(codomain_axes)
     N = K + length(domain_axes)
     dest_axes = (codomain_axes..., domain_axes...)
@@ -217,11 +211,8 @@ function TensorAlgebra.unmatricize(
         src_block = m[bI_src]
         dest_sects = ntuple(d -> sectors(dest_axes[d])[dest_bk[d]], Val(N))
         dest_dims = ntuple(d -> blocklengths(dest_axes[d])[dest_bk[d]], Val(N))
-        dest_data = reshape(data(src_block), dest_dims)
-        dest_delta = AbelianSectorDelta{T}(dest_sects)
-        phase = fermion_contraction_phase(dest_delta, K)
-        isone(phase) || (dest_data .*= phase)
-        dest_block = AbelianSectorArray(dest_sects, dest_data)
+        dest_block = AbelianSectorArray(dest_sects, reshape(data(src_block), dest_dims))
+        contraction_twist!(dest_block, K)
         a[Block(dest_bk...)] = dest_block
     end
 

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -192,3 +192,68 @@ function TensorAlgebra.bipermutedimsopadd!(
     end
     return y
 end
+
+# ========================  contractopadd! (Matricize{SectorFusion})  ========================
+# permute(a1) → permute(a2) → twist(a2's contracted legs) → matricize → gemm →
+# unmatricize → permute(a_dest). Mirrors TensorAlgebra.contractopadd!_matricize but
+# splits `matricizeop` into separate permute/matricize steps so the fermion twist
+# can sit between them as a first-class step. `contraction_twist!` is a no-op for
+# bosonic sectors, so this pipeline is correct for any AbelianStyle input.
+
+"""
+    contraction_twist!(a::AbelianSectorArray, ndims_codomain::Int) -> a
+
+Apply the twist convention for the supertrace formalism of fermionic contractions.
+This means that ``⟨i| ⋅ |j⟩ = δᵢⱼ``, and ``|i⟩ ⋅ ⟨j| = θᵢⱼ δᵢⱼ``.
+Here, ``θᵢⱼ = ±1`` is defined as the phase from applying a self-crossing,
+which is always ``1`` for bosonic symmetries, but can be ``-1`` for odd fermion charges.
+
+Equivalent to `twist!(a, (i for i in 1:ndims_codomain if isdual(a, i)))`.
+A no-op unless `BraidingStyle(sectortype(a))` is `Fermionic`.
+
+See also [`twist!`](@ref).
+"""
+function contraction_twist!(a::AbstractArray, ndims_codomain::Int)
+    return twist!(a, (i for i in 1:ndims_codomain if isdual(a, i)))
+end
+
+#=
+This is an overload that follows the standard TensorAlgebra implementation,
+with the single exception of inserting a `contraction_twist!` call before the matricization.
+This is important to have fermionic contractions not depend on the contraction order.
+=#
+function TensorAlgebra.contractopadd!_matricize(
+        algorithm::TensorAlgebra.Matricize{SectorFusion},
+        a_dest::AbstractArray, perm_dest_codomain, perm_dest_domain,
+        op1, a1::AbstractArray, perm1_codomain, perm1_domain,
+        op2, a2::AbstractArray, perm2_codomain, perm2_domain,
+        α::Number, β::Number
+    )
+    perm_dest = (perm_dest_codomain..., perm_dest_domain...)
+    invperm_codomain, invperm_domain =
+        blocks(TensorAlgebra.biperm(invperm(perm_dest), length(perm1_codomain)))
+    check_input(
+        TensorAlgebra.contract!,
+        a_dest, invperm_codomain, invperm_domain,
+        a1, perm1_codomain, perm1_domain,
+        a2, perm2_codomain, perm2_domain
+    )
+
+    a1_mat = TensorAlgebra.matricizeop(
+        algorithm.fusion_style,
+        op1,
+        a1,
+        perm1_codomain,
+        perm1_domain
+    )
+    # matricizeop + contraction_twist
+    a2_perm = TensorAlgebra.permutedimsop(op2, a2, perm2_codomain, perm2_domain)
+    contraction_twist!(a2_perm, length(perm2_codomain))
+    a2_mat = matricize(a2_perm, Val(length(perm2_codomain)))
+
+    a_dest_mat = a1_mat * a2_mat
+    TensorAlgebra.unmatricizeadd!(
+        algorithm.fusion_style, a_dest, a_dest_mat, invperm_codomain, invperm_domain, α, β
+    )
+    return a_dest
+end

--- a/src/tensoralgebra.jl
+++ b/src/tensoralgebra.jl
@@ -222,7 +222,7 @@ This is an overload that follows the standard TensorAlgebra implementation,
 with the single exception of inserting a `contraction_twist!` call before the matricization.
 This is important to have fermionic contractions not depend on the contraction order.
 =#
-function TensorAlgebra.contractopadd!_matricize(
+function TensorAlgebra.contractopadd!(
         algorithm::TensorAlgebra.Matricize{SectorFusion},
         a_dest::AbstractArray, perm_dest_codomain, perm_dest_domain,
         op1, a1::AbstractArray, perm1_codomain, perm1_domain,
@@ -241,15 +241,12 @@ function TensorAlgebra.contractopadd!_matricize(
 
     a1_mat = TensorAlgebra.matricizeop(
         algorithm.fusion_style,
-        op1,
-        a1,
-        perm1_codomain,
-        perm1_domain
+        op1, a1, perm1_codomain, perm1_domain
     )
     # matricizeop + contraction_twist
     a2_perm = TensorAlgebra.permutedimsop(op2, a2, perm2_codomain, perm2_domain)
     contraction_twist!(a2_perm, length(perm2_codomain))
-    a2_mat = matricize(a2_perm, Val(length(perm2_codomain)))
+    a2_mat = matricize(algorithm.fusion_style, a2_perm, Val(length(perm2_codomain)))
 
     a_dest_mat = a1_mat * a2_mat
     TensorAlgebra.unmatricizeadd!(

--- a/test/test_fermionic.jl
+++ b/test/test_fermionic.jl
@@ -1,8 +1,8 @@
 import GradedArrays
 using BlockArrays: Block, blocklengths, blocksize
 using BlockSparseArrays: eachblockstoredindex
-using GradedArrays: AbelianGradedArray, AbelianSectorArray, AbelianSectorDelta,
-    SectorRange, U1, data, dual, flip, gradedrange, isdual, sectoraxes, sectors
+using GradedArrays: AbelianGradedArray, AbelianSectorArray, AbelianSectorDelta, SectorRange,
+    U1, data, dual, flip, gradedrange, isdual, sectoraxes, sectors
 using Random: randn!
 using TensorAlgebra: contract, matricize, unmatricize
 using TensorKitSectors: TensorKitSectors as TKS

--- a/test/test_fermionic.jl
+++ b/test/test_fermionic.jl
@@ -1,13 +1,45 @@
 import GradedArrays
-using GradedArrays: AbelianSectorArray, AbelianSectorDelta, SectorRange, U1, dual, sectors
+using BlockArrays: Block, blocklengths, blocksize
+using BlockSparseArrays: eachblockstoredindex
+using GradedArrays: AbelianGradedArray, AbelianSectorArray, AbelianSectorDelta,
+    SectorRange, U1, data, dual, flip, gradedrange, isdual, sectoraxes, sectors
 using Random: randn!
+using TensorAlgebra: contract, matricize, unmatricize
 using TensorKitSectors: TensorKitSectors as TKS
 using Test: @test, @testset
 
-# Fermionic sector aliases: FermionParity has two values, even (false) and odd (true),
-# both with quantum dimension 1.
 const fP0 = SectorRange(TKS.FermionParity(false))  # even parity
 const fP1 = SectorRange(TKS.FermionParity(true))   # odd parity
+
+function randn_blockdiagonal(elt::Type, axs::Tuple)
+    a = AbelianGradedArray{elt}(undef, axs...)
+    blockdiaglength = minimum(blocksize(a))
+    N = ndims(a)
+    for i in 1:blockdiaglength
+        block_sectors = ntuple(d -> sectors(axs[d])[i], N)
+        block_dims = ntuple(d -> blocklengths(axs[d])[i], N)
+        block_data = randn!(Array{elt}(undef, block_dims...))
+        a[Block(ntuple(Returns(i), N)...)] = AbelianSectorArray(block_sectors, block_data)
+    end
+    return a
+end
+
+# Dense materialization for AbelianGradedArray (scalar indexing is disallowed,
+# so `convert(Array, ...)` doesn't work). Iterate stored blocks and copy each
+# block's dense data into the matching slice of a zero-initialized output.
+function to_dense(a::AbelianGradedArray{T, N}) where {T, N}
+    out = zeros(T, size(a))
+    bls = ntuple(d -> blocklengths(axes(a, d)), N)
+    for bI in eachblockstoredindex(a)
+        bk = ntuple(d -> Int(Tuple(bI)[d]), N)
+        ranges = ntuple(N) do d
+            start = sum(view(bls[d], 1:(bk[d] - 1)); init = 0) + 1
+            return start:(start + bls[d][bk[d]] - 1)
+        end
+        out[ranges...] = data(a[bI])
+    end
+    return out
+end
 
 @testset "masked_inversion_parity" begin
     mip = GradedArrays.masked_inversion_parity
@@ -36,38 +68,203 @@ const fP1 = SectorRange(TKS.FermionParity(true))   # odd parity
     # Two odd, one even: only odd-odd pairs count
     @test mip((true, false, true), (3, 2, 1)) == -1
     @test mip((true, false, true), (1, 2, 3)) == 1
+    @test mip((true, false, true), (3, 1, 2)) == -1
 end
 
 @testset "fermion_permutation_phase" begin
     fpp = GradedArrays.fermion_permutation_phase
 
-    # Bosonic: always +1
-    delta_bos = AbelianSectorDelta{Float64}((U1(0), U1(1)))
-    @test fpp(delta_bos, (2, 1)) == true  # Bosonic returns `true` (== 1)
+    # Bosonic (U1): always +1 regardless of permutation
+    u0 = SectorRange(TKS.U1Irrep(0))
+    u1 = SectorRange(TKS.U1Irrep(1))
+    d_bos = AbelianSectorDelta{Float64}((u0, u1))
+    @test fpp(d_bos, (2, 1)) == 1
+    @test fpp(d_bos, (1, 2)) == 1
 
-    # Fermionic: even parity swap → +1
-    delta_even = AbelianSectorDelta{Float64}((fP0, fP0))
-    @test fpp(delta_even, (2, 1)) == 1
+    # Even parity only: always +1
+    d_even = AbelianSectorDelta{Float64}((fP0, fP0))
+    @test fpp(d_even, (2, 1)) == 1
+    @test fpp(d_even, (1, 2)) == 1
 
-    # Fermionic: two odd parity swap → -1
-    delta_odd = AbelianSectorDelta{Float64}((fP1, fP1))
-    @test fpp(delta_odd, (2, 1)) == -1
+    # Two odd sectors: identity = +1, swap = -1
+    d_odd = AbelianSectorDelta{Float64}((fP1, fP1))
+    @test fpp(d_odd, (1, 2)) == 1
+    @test fpp(d_odd, (2, 1)) == -1
 
-    # Fermionic: one odd one even swap → +1
-    delta_mixed = AbelianSectorDelta{Float64}((fP1, fP0))
-    @test fpp(delta_mixed, (2, 1)) == 1
+    # Mixed even/odd: swap gives +1 (only odd-odd pairs contribute)
+    d_mix = AbelianSectorDelta{Float64}((fP0, fP1))
+    @test fpp(d_mix, (2, 1)) == 1
+
+    d_mix2 = AbelianSectorDelta{Float64}((fP1, fP0))
+    @test fpp(d_mix2, (2, 1)) == 1
+
+    # Three odd sectors
+    d3 = AbelianSectorDelta{Float64}((fP1, fP1, fP1))
+    @test fpp(d3, (1, 2, 3)) == 1
+    @test fpp(d3, (2, 3, 1)) == 1
+    @test fpp(d3, (2, 1, 3)) == -1
+    @test fpp(d3, (3, 2, 1)) == -1
 end
 
-@testset "AbelianSectorArray permutedims applies fermionic phase" begin
-    # Two odd-parity legs: permuting should negate
-    d = randn!(Matrix{Float64}(undef, 1, 1))
-    s = AbelianSectorArray((fP1, fP1), copy(d))
-    sp = permutedims(s, (2, 1))
-    @test sp[1, 1] ≈ -d[1, 1]
+@testset "permutedims on fermionic AbelianSectorArray" begin
+    # Two odd sectors: swap picks up -1 phase
+    sa = AbelianSectorArray((fP1, fP1), fill(3.0, 1, 1))
+    sp = permutedims(sa, (2, 1))
+    @test sp[1, 1] ≈ -3.0
+    @test sectoraxes(sp) == (fP1, fP1)
 
-    # Two even-parity legs: no phase
-    d_even = randn!(Matrix{Float64}(undef, 1, 1))
-    s_even = AbelianSectorArray((fP0, fP0), copy(d_even))
-    sp_even = permutedims(s_even, (2, 1))
-    @test sp_even[1, 1] ≈ d_even[1, 1]
+    # Two even sectors: swap gives no phase
+    sa_even = AbelianSectorArray((fP0, fP0), fill(3.0, 1, 1))
+    sp_even = permutedims(sa_even, (2, 1))
+    @test sp_even[1, 1] ≈ 3.0
+
+    # Mixed (even, odd): swap gives no phase
+    sa_mix = AbelianSectorArray((fP0, fP1), fill(3.0, 1, 1))
+    sp_mix = permutedims(sa_mix, (2, 1))
+    @test sp_mix[1, 1] ≈ 3.0
+    @test sectoraxes(sp_mix) == (fP1, fP0)
+
+    # Double permutation recovers original (phase squares to 1)
+    @test permutedims(permutedims(sa, (2, 1)), (2, 1))[1, 1] ≈ sa[1, 1]
+
+    # Three-index: cyclic permutation of 3 odd sectors → even crossings → +1
+    sa3 = AbelianSectorArray((fP1, fP1, fP1), fill(2.0, 1, 1, 1))
+    @test permutedims(sa3, (2, 3, 1))[1, 1, 1] ≈ 2.0
+    @test permutedims(sa3, (3, 2, 1))[1, 1, 1] ≈ -2.0
+    @test permutedims(sa3, (2, 1, 3))[1, 1, 1] ≈ -2.0
+
+    # Two odd sectors with non-unit data: verify value propagates
+    sa_val = AbelianSectorArray((fP1, fP1), fill(7.5, 1, 1))
+    @test permutedims(sa_val, (2, 1))[1, 1] ≈ -7.5
+
+    # No phase for bosonic (U1) sectors even though same permutation
+    u1 = SectorRange(TKS.U1Irrep(1))
+    sa_u1 = AbelianSectorArray((u1, u1), fill(3.0, 1, 1))
+    sp_u1 = permutedims(sa_u1, (2, 1))
+    @test sp_u1[1, 1] ≈ 3.0
+end
+
+@testset "matricize/unmatricize round-trip for fermionic AbelianSectorArray" begin
+    # Even dual codomain leg: twist = +1, no phase modification
+    sa_even_dual = AbelianSectorArray((dual(fP0), fP0), fill(5.0, 1, 1))
+    @test isdual(axes(sa_even_dual, 1))
+    m_even = matricize(sa_even_dual, (1,), (2,))
+    @test m_even[1, 1] ≈ 5.0
+
+    rt_even = unmatricize(m_even, (axes(sa_even_dual, 1),), (axes(sa_even_dual, 2),))
+    @test rt_even[1, 1] ≈ 5.0
+
+    # Non-dual codomain leg: twist not applied regardless of parity
+    sa_odd_nondual = AbelianSectorArray((fP1, fP1), fill(5.0, 1, 1))
+    @test !isdual(axes(sa_odd_nondual, 1))
+    m_nondual = matricize(sa_odd_nondual, (1,), (2,))
+    @test m_nondual[1, 1] ≈ 5.0
+
+    # Odd dual codomain leg: twist = -1 → phase -1 applied during matricize
+    sa_odd_dual = AbelianSectorArray((dual(fP1), fP1), fill(5.0, 1, 1))
+    @test isdual(axes(sa_odd_dual, 1))
+    m_odd = matricize(sa_odd_dual, (1,), (2,))
+    @test m_odd[1, 1] ≈ -5.0
+
+    # Round-trip: unmatricize applies same twist → -1 * (-5.0) = 5.0
+    rt_odd = unmatricize(m_odd, (axes(sa_odd_dual, 1),), (axes(sa_odd_dual, 2),))
+    @test rt_odd[1, 1] ≈ 5.0
+
+    # Two odd dual codomain legs: phase = (-1) * (-1) = +1
+    sa_two_odd_dual = AbelianSectorArray((dual(fP1), dual(fP1), fP1), fill(3.0, 1, 1, 1))
+    m_two = matricize(sa_two_odd_dual, (1, 2), (3,))
+    @test m_two[1, 1] ≈ 3.0
+
+    rt_two = unmatricize(
+        m_two,
+        (axes(sa_two_odd_dual, 1), axes(sa_two_odd_dual, 2)),
+        (axes(sa_two_odd_dual, 3),)
+    )
+    @test rt_two[1, 1, 1] ≈ 3.0
+end
+
+const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
+
+# For all-odd blocks, the total phase from permutation + matricize twist is -1,
+# so the GradedArray result equals -1 * the dense result.
+@testset "contract GradedArray with FermionParity (eltype=$elt)" for elt in
+    elts
+
+    r_odd = gradedrange([fP1 => 2])
+
+    @testset "permutedims of all-odd GradedArray picks up -1 phase" begin
+        a = randn_blockdiagonal(elt, (r_odd, dual(r_odd)))
+        a_perm = permutedims(a, (2, 1))
+        a_dense_perm = permutedims(to_dense(a), (2, 1))
+        @test to_dense(a_perm) ≈ -1 * a_dense_perm
+    end
+
+    @testset "matrix-matrix contraction" begin
+        for r1 in (r_odd, dual(r_odd)),
+                r2 in (r_odd, dual(r_odd)),
+                r3 in (r_odd, dual(r_odd))
+
+            a1 = randn_blockdiagonal(elt, (r1, dual(r2)))
+            a2 = randn_blockdiagonal(elt, (r2, r3))
+            a1_dense = to_dense(a1)
+            a2_dense = to_dense(a2)
+            a_dest, labels_dest = contract(a1, (-1, 1), a2, (1, -2))
+            a_dest_dense, labels_dest_dense = contract(a1_dense, (-1, 1), a2_dense, (1, -2))
+            @test labels_dest == labels_dest_dense
+            a_dest_dense = isdual(r2) ? -a_dest_dense : a_dest_dense
+            @test to_dense(a_dest) ≈ a_dest_dense
+
+            # does not depend on input order
+            a_dest = permutedims(contract(a2, (1, -2), a1, (-1, 1))[1], (2, 1))
+            @test to_dense(a_dest) ≈ a_dest_dense
+
+            a_dest = contract((-1, -2), a2, (1, -2), a1, (-1, 1))
+            @test to_dense(a_dest) ≈ a_dest_dense
+
+            # does not depend on permutations
+            a3 = permutedims(a1, (2, 1))
+            a_dest, _ = contract(a3, (1, -1), a2, (1, -2))
+            @test to_dense(a_dest) ≈ a_dest_dense
+
+            a4 = permutedims(a2, (2, 1))
+            a_dest, _ = contract(a1, (-1, 1), a4, (-2, 1))
+            @test to_dense(a_dest) ≈ a_dest_dense
+
+            a_dest, _ = contract(a3, (1, -1), a4, (-2, 1))
+            @test to_dense(a_dest) ≈ a_dest_dense
+        end
+    end
+
+    # @testset "matrix-matrix contraction B: total phase -1" begin
+    #     # labels (1,-1,-2,2) × (2,1,-3,-4): P2=-1, T1=-1, T2=+1, U=-1 → total=-1
+    #     a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+    #     a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+    #     a1_dense = to_dense(a1)
+    #     a2_dense = to_dense(a2)
+    #     a_dest, _ = contract(a1, (1, -1, -2, 2), a2, (2, 1, -3, -4))
+    #     a_dest_dense, _ = contract(a1_dense, (1, -1, -2, 2), a2_dense, (2, 1, -3, -4))
+    #     @test to_dense(a_dest) ≈ -1 * a_dest_dense
+    # end
+    #
+    # @testset "matrix-matrix contraction D: total phase -1" begin
+    #     # labels (-1,1,2,-2) × (2,-3,1,-4): P1=+1, T1=-1, P2=+1, T2=-1, U=-1 → total=-1
+    #     a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+    #     a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+    #     a1_dense = to_dense(a1)
+    #     a2_dense = to_dense(a2)
+    #     a_dest, _ = contract(a1, (-1, 1, 2, -2), a2, (2, -3, 1, -4))
+    #     a_dest_dense, _ = contract(a1_dense, (-1, 1, 2, -2), a2_dense, (2, -3, 1, -4))
+    #     @test to_dense(a_dest) ≈ -1 * a_dest_dense
+    # end
+    #
+    # @testset "matrix-matrix contraction G: total phase -1" begin
+    #     # labels (1,2,-1,-2) × (2,-3,1,-4): P1=+1, T1=+1, P2=+1, T2=-1, U=+1 → total=-1
+    #     a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+    #     a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+    #     a1_dense = to_dense(a1)
+    #     a2_dense = to_dense(a2)
+    #     a_dest, _ = contract(a1, (1, 2, -1, -2), a2, (2, -3, 1, -4))
+    #     a_dest_dense, _ = contract(a1_dense, (1, 2, -1, -2), a2_dense, (2, -3, 1, -4))
+    #     @test to_dense(a_dest) ≈ -1 * a_dest_dense
+    # end
 end

--- a/test/test_fermionic.jl
+++ b/test/test_fermionic.jl
@@ -235,36 +235,36 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         end
     end
 
-    # @testset "matrix-matrix contraction B: total phase -1" begin
-    #     # labels (1,-1,-2,2) × (2,1,-3,-4): P2=-1, T1=-1, T2=+1, U=-1 → total=-1
-    #     a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
-    #     a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
-    #     a1_dense = to_dense(a1)
-    #     a2_dense = to_dense(a2)
-    #     a_dest, _ = contract(a1, (1, -1, -2, 2), a2, (2, 1, -3, -4))
-    #     a_dest_dense, _ = contract(a1_dense, (1, -1, -2, 2), a2_dense, (2, 1, -3, -4))
-    #     @test to_dense(a_dest) ≈ -1 * a_dest_dense
-    # end
-    #
-    # @testset "matrix-matrix contraction D: total phase -1" begin
-    #     # labels (-1,1,2,-2) × (2,-3,1,-4): P1=+1, T1=-1, P2=+1, T2=-1, U=-1 → total=-1
-    #     a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
-    #     a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
-    #     a1_dense = to_dense(a1)
-    #     a2_dense = to_dense(a2)
-    #     a_dest, _ = contract(a1, (-1, 1, 2, -2), a2, (2, -3, 1, -4))
-    #     a_dest_dense, _ = contract(a1_dense, (-1, 1, 2, -2), a2_dense, (2, -3, 1, -4))
-    #     @test to_dense(a_dest) ≈ -1 * a_dest_dense
-    # end
-    #
-    # @testset "matrix-matrix contraction G: total phase -1" begin
-    #     # labels (1,2,-1,-2) × (2,-3,1,-4): P1=+1, T1=+1, P2=+1, T2=-1, U=+1 → total=-1
-    #     a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
-    #     a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
-    #     a1_dense = to_dense(a1)
-    #     a2_dense = to_dense(a2)
-    #     a_dest, _ = contract(a1, (1, 2, -1, -2), a2, (2, -3, 1, -4))
-    #     a_dest_dense, _ = contract(a1_dense, (1, 2, -1, -2), a2_dense, (2, -3, 1, -4))
-    #     @test to_dense(a_dest) ≈ -1 * a_dest_dense
-    # end
+    @testset "matrix-matrix contraction B: total phase -1" begin
+        # labels (1,-1,-2,2) × (2,1,-3,-4): P2=-1, T1=-1, T2=+1, U=-1 → total=-1
+        a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+        a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+        a1_dense = to_dense(a1)
+        a2_dense = to_dense(a2)
+        a_dest, _ = contract(a1, (1, -1, -2, 2), a2, (2, 1, -3, -4))
+        a_dest_dense, _ = contract(a1_dense, (1, -1, -2, 2), a2_dense, (2, 1, -3, -4))
+        @test to_dense(a_dest) ≈ -1 * a_dest_dense
+    end
+
+    @testset "matrix-matrix contraction D: total phase -1" begin
+        # labels (-1,1,2,-2) × (2,-3,1,-4): P1=+1, T1=-1, P2=+1, T2=-1, U=-1 → total=-1
+        a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+        a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+        a1_dense = to_dense(a1)
+        a2_dense = to_dense(a2)
+        a_dest, _ = contract(a1, (-1, 1, 2, -2), a2, (2, -3, 1, -4))
+        a_dest_dense, _ = contract(a1_dense, (-1, 1, 2, -2), a2_dense, (2, -3, 1, -4))
+        @test to_dense(a_dest) ≈ -1 * a_dest_dense
+    end
+
+    @testset "matrix-matrix contraction G: total phase -1" begin
+        # labels (1,2,-1,-2) × (2,-3,1,-4): P1=+1, T1=+1, P2=+1, T2=-1, U=+1 → total=-1
+        a1 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+        a2 = randn_blockdiagonal(elt, (r_odd, r_odd, dual(r_odd), dual(r_odd)))
+        a1_dense = to_dense(a1)
+        a2_dense = to_dense(a2)
+        a_dest, _ = contract(a1, (1, 2, -1, -2), a2, (2, -3, 1, -4))
+        a_dest_dense, _ = contract(a1_dense, (1, 2, -1, -2), a2_dense, (2, -3, 1, -4))
+        @test to_dense(a_dest) ≈ -1 * a_dest_dense
+    end
 end

--- a/test/test_fermionic.jl
+++ b/test/test_fermionic.jl
@@ -144,45 +144,6 @@ end
     @test sp_u1[1, 1] ≈ 3.0
 end
 
-@testset "matricize/unmatricize round-trip for fermionic AbelianSectorArray" begin
-    # Even dual codomain leg: twist = +1, no phase modification
-    sa_even_dual = AbelianSectorArray((dual(fP0), fP0), fill(5.0, 1, 1))
-    @test isdual(axes(sa_even_dual, 1))
-    m_even = matricize(sa_even_dual, (1,), (2,))
-    @test m_even[1, 1] ≈ 5.0
-
-    rt_even = unmatricize(m_even, (axes(sa_even_dual, 1),), (axes(sa_even_dual, 2),))
-    @test rt_even[1, 1] ≈ 5.0
-
-    # Non-dual codomain leg: twist not applied regardless of parity
-    sa_odd_nondual = AbelianSectorArray((fP1, fP1), fill(5.0, 1, 1))
-    @test !isdual(axes(sa_odd_nondual, 1))
-    m_nondual = matricize(sa_odd_nondual, (1,), (2,))
-    @test m_nondual[1, 1] ≈ 5.0
-
-    # Odd dual codomain leg: twist = -1 → phase -1 applied during matricize
-    sa_odd_dual = AbelianSectorArray((dual(fP1), fP1), fill(5.0, 1, 1))
-    @test isdual(axes(sa_odd_dual, 1))
-    m_odd = matricize(sa_odd_dual, (1,), (2,))
-    @test m_odd[1, 1] ≈ -5.0
-
-    # Round-trip: unmatricize applies same twist → -1 * (-5.0) = 5.0
-    rt_odd = unmatricize(m_odd, (axes(sa_odd_dual, 1),), (axes(sa_odd_dual, 2),))
-    @test rt_odd[1, 1] ≈ 5.0
-
-    # Two odd dual codomain legs: phase = (-1) * (-1) = +1
-    sa_two_odd_dual = AbelianSectorArray((dual(fP1), dual(fP1), fP1), fill(3.0, 1, 1, 1))
-    m_two = matricize(sa_two_odd_dual, (1, 2), (3,))
-    @test m_two[1, 1] ≈ 3.0
-
-    rt_two = unmatricize(
-        m_two,
-        (axes(sa_two_odd_dual, 1), axes(sa_two_odd_dual, 2)),
-        (axes(sa_two_odd_dual, 3),)
-    )
-    @test rt_two[1, 1, 1] ≈ 3.0
-end
-
 const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 
 # For all-odd blocks, the total phase from permutation + matricize twist is -1,


### PR DESCRIPTION
Follow-up to #135 (fermionic symmetries), with fallout from the #148 type redesign and a rework of how fermionic phases are threaded through `TensorAlgebra`.

## Approach

`matricize`/`unmatricize` and `contract` had been sharing a single notion of "fermionic phase", but they actually want different ones:

- `matricize`/`unmatricize` are infrastructure for factorizations and matrix functions (`eigen`, `svd`, `qr`, `exp`, …). They live in the *trace formalism*: no twists, just a reshape. Round-tripping is the identity on data, which is what downstream `LinearAlgebra` overloads silently assume.
- `contract` lives in the *supertrace formalism*, where ``|i⟩ ⋅ ⟨j| = θᵢⱼ δᵢⱼ`` with ``θᵢⱼ`` the self-crossing phase. That convention is what makes `contract` independent of argument order on fermionic sectors.

So `matricize`/`unmatricize` no longer touch phases. `contract` is handled by an overload of `TensorAlgebra.contractopadd!_matricize` for `SectorFusion` that slots `contraction_twist!` between the permute and matricize of the second operand. The twist is a no-op for bosonic sectors, so the same path serves both worlds.

Two helpers:

- `twist!(a, dims)`: general in-place leg twist.
- `contraction_twist!(a, ndims_codomain) ≡ twist!(a, (i for i in 1:ndims_codomain if isdual(a, i)))`: the supertrace convention at contract time.

## Other changes

- `test/test_fermionic.jl` restored from a 47-test stub to full coverage, rewritten against the post-#148 type names and the scalar-indexing prohibition.
- Restored the eager fallback in `FI.permuteddims(::AbelianSectorArray, perm)` for non-bosonic braiding — it had silently regressed to a lazy view that dropped the permutation phase.
