### PR TITLE
Apply the fermionic leg-reversal sign in conj on graded arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -316,9 +316,13 @@ end
 # axis types (`SectorRange`/`GradedOneTo`/`SectorOneTo`). Without the axis flip,
 # `conj(t)` would leave bra-layer tensors with the same duality as the ket, and
 # any contraction between them would silently pair non-dual against non-dual.
+# Delegate per block to `conj(::AbelianSectorArray)`, which carries the fermionic
+# reversal phase that a bare block-wise data conjugation would drop.
 function Base.conj(a::AbelianGradedArray{T, N, D, S}) where {T, N, D, S}
     return AbelianGradedArray{T, N, D, S}(
-        Dict{NTuple{N, Int}, D}(k => conj(v) for (k, v) in a.blockdata),
+        Dict{NTuple{N, Int}, D}(
+            k => data(conj(view(a, Block(k...)))) for k in keys(a.blockdata)
+        ),
         map(conj, a.axes)
     )
 end

--- a/src/abeliansectorarray.jl
+++ b/src/abeliansectorarray.jl
@@ -139,6 +139,23 @@ function twist!(a::AbelianSectorArray, dims)
     return a
 end
 
+# ========================  conj  ========================
+
+# Op A (the ket->bra involution) on a single block: conjugate the data, flip the
+# duality of every axis, and apply the fermionic phase from reversing the leg
+# order (`reverse(1:N)`). Bosonic (and even-parity fermionic) sectors give
+# `phase == 1`, so the data is just conjugated; odd-parity fermionic legs pick up
+# the `-1` from `masked_inversion_parity` that the bare data conjugation drops.
+# `phase * conj(...)` (rather than an in-place `.*=`) keeps a fresh buffer:
+# `conj` aliases its argument for real data, so scaling in place would corrupt
+# the block this view shares with the parent array.
+function Base.conj(x::AbelianSectorArray{<:Any, N}) where {N}
+    rev = reverse(ntuple(identity, Val(N)))
+    phase = fermion_permutation_phase(sector(x), rev)
+    new_data = isone(phase) ? conj(data(x)) : phase * conj(data(x))
+    return AbelianSectorArray(map(conj, x.sectors), new_data)
+end
+
 # ========================  Other  ========================
 
 function KroneckerArrays.:(⊗)(

--- a/src/abstractgradedarray.jl
+++ b/src/abstractgradedarray.jl
@@ -20,13 +20,6 @@ function BlockSparseArrays.isblockdiagonal(A::AbstractGradedMatrix)
     return true
 end
 
-# Block-aware `LinearAlgebra.isdiag` for graded matrices. The generic
-# `LinearAlgebra.isdiag` would fall through to `_isbanded_impl`'s scalar-indexed
-# `iszero(view)` iteration, which throws on block storage. A graded matrix is
-# diagonal iff it is block-diagonal (no off-diagonal blocks stored) and each
-# stored block is itself diagonal — the latter checked block-by-block to avoid
-# materializing the whole matrix.
-
 # Scalar indexing is not supported for graded arrays.
 function Base.getindex(::AbstractGradedArray, ::Vararg{Int})
     return error(

--- a/test/test_fermionic.jl
+++ b/test/test_fermionic.jl
@@ -144,6 +144,43 @@ end
     @test sp_u1[1, 1] ≈ 3.0
 end
 
+@testset "conj on fermionic AbelianSectorArray" begin
+    # Two odd sectors: reversing 2 odd legs is one odd-odd inversion → -1 phase
+    sa = AbelianSectorArray((fP1, fP1), fill(3.0, 1, 1))
+    sc = conj(sa)
+    @test sc[1, 1] ≈ -3.0
+    @test sectoraxes(sc) == (dual(fP1), dual(fP1))
+
+    # Two even sectors: no phase, data just conjugated
+    @test conj(AbelianSectorArray((fP0, fP0), fill(3.0, 1, 1)))[1, 1] ≈ 3.0
+
+    # Mixed (even, odd): single odd leg → no odd-odd inversion → no phase
+    sa_mix = AbelianSectorArray((fP0, fP1), fill(3.0, 1, 1))
+    @test conj(sa_mix)[1, 1] ≈ 3.0
+    @test sectoraxes(conj(sa_mix)) == (dual(fP0), dual(fP1))
+
+    # Three odd sectors: reverse(1,2,3) has 3 odd-odd inversions → odd → -1 phase
+    @test conj(AbelianSectorArray((fP1, fP1, fP1), fill(2.0, 1, 1, 1)))[1, 1, 1] ≈ -2.0
+
+    # Complex data: conjugates the data *and* applies the fermionic phase
+    sa_c = AbelianSectorArray((fP1, fP1), fill(1.0 + 2.0im, 1, 1))
+    @test conj(sa_c)[1, 1] ≈ -(1.0 - 2.0im)
+
+    # Involution: conj ∘ conj recovers data and sectors (phase squares to 1)
+    @test conj(conj(sa))[1, 1] ≈ sa[1, 1]
+    @test sectoraxes(conj(conj(sa))) == (fP1, fP1)
+    @test conj(conj(sa_c))[1, 1] ≈ sa_c[1, 1]
+
+    # Mutation safety: conj must not scale the parent block in place
+    sa_mut = AbelianSectorArray((fP1, fP1), fill(5.0, 1, 1))
+    conj(sa_mut)
+    @test sa_mut[1, 1] ≈ 5.0
+
+    # Bosonic (U1) sectors: no fermionic phase, just data conj
+    u1 = SectorRange(TKS.U1Irrep(1))
+    @test conj(AbelianSectorArray((u1, u1), fill(1.0 + 2.0im, 1, 1)))[1, 1] ≈ 1.0 - 2.0im
+end
+
 const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
 
 # For all-odd blocks, the total phase from permutation + matricize twist is -1,
@@ -158,6 +195,21 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
         a_perm = permutedims(a, (2, 1))
         a_dense_perm = permutedims(to_dense(a), (2, 1))
         @test to_dense(a_perm) ≈ -1 * a_dense_perm
+    end
+
+    @testset "conj of all-odd GradedArray picks up -1 phase" begin
+        a = randn_blockdiagonal(elt, (r_odd, dual(r_odd)))
+        a_dense_before = to_dense(a)
+        ac = conj(a)
+        # Every stored block is all-odd → reversal phase -1, on top of data conj.
+        @test to_dense(ac) ≈ -1 * conj(a_dense_before)
+        # Axis dualities are flipped.
+        @test isdual(axes(ac, 1)) == !isdual(axes(a, 1))
+        @test isdual(axes(ac, 2)) == !isdual(axes(a, 2))
+        # Involution: conj ∘ conj recovers the original.
+        @test to_dense(conj(ac)) ≈ a_dense_before
+        # Mutation safety: conj must not scale the parent's blocks in place.
+        @test to_dense(a) ≈ a_dense_before
     end
 
     @testset "matrix-matrix contraction" begin


### PR DESCRIPTION
## Summary

`Base.conj` on an `AbelianGradedArray` is the ket→bra involution: conjugate the block data and flip the duality of every axis. For fermionic sectors it also has to pick up the sign from reversing the leg order, which the previous block-wise implementation dropped, so `conj` of an odd-parity block came out with the wrong sign.

This defines `conj` on `AbelianSectorArray` (the per-block view), where the reversal sign comes from the existing `fermion_permutation_phase`, and has the graded-array method delegate to it block by block. Bosonic and even-parity inputs are unaffected, since the phase is `1` there. Also drops a stray comment left over from an earlier change.