### PR TITLE
Fix FusedGradedMatrix matrix functions erroring on Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/fusedgradedmatrix.jl
+++ b/src/fusedgradedmatrix.jl
@@ -75,12 +75,20 @@ LinearAlgebra.isdiag(A::FusedGradedMatrix) = all(LinearAlgebra.isdiag, A.blocks)
 # Per-block result eltypes may differ (e.g. `sqrt(::Matrix{Float64})` returns
 # `Matrix{ComplexF64}` via Schur even when each block is real-PSD), so unify to the
 # `promote_type` of all returned blocks before reconstructing.
+#
+# The target eltype `T` is passed through a type-parameter barrier so the `convert`
+# target is concrete to inference. Splicing a runtime `T` straight into
+# `convert(AbstractMatrix{T}, b)` makes older Julia widen the block dictionary to an
+# abstract `AbstractMatrix`, and the reconstruction then throws a `TypeError`.
+function unify_block_eltype(blocks, ::Type{T}) where {T}
+    return map(b -> convert(AbstractMatrix{T}, b), blocks)
+end
+
 for f in TensorAlgebra.MATRIX_FUNCTIONS
     @eval function Base.$f(A::FusedGradedMatrix)
         raw = map(Base.$f, A.blocks)
         T = mapreduce(eltype, promote_type, raw; init = eltype(A))
-        blocks = map(b -> eltype(b) === T ? b : convert(AbstractMatrix{T}, b), raw)
-        return FusedGradedMatrix(A.codomain, A.domain, blocks)
+        return FusedGradedMatrix(A.codomain, A.domain, unify_block_eltype(raw, T))
     end
 end
 

--- a/test/test_data.jl
+++ b/test/test_data.jl
@@ -66,6 +66,19 @@ using Test: @test, @test_throws, @testset
             sm = SectorMatrix(U1(0), ones(2, 3))
             @test_throws Exception (m6[Block(1, 2)] = sm)
         end
+
+        @testset "Block-diagonal matrix functions ($f)" for f in (sqrt, exp, log)
+            # Each function acts block-wise and reconstructs a concretely-typed
+            # `FusedGradedMatrix`. The eltype unification previously widened the
+            # block dictionary to an abstract `AbstractMatrix` on older Julia,
+            # throwing a `TypeError` on reconstruction.
+            blocks = [[2.0 0.0; 0.0 2.0], [3.0 0.0 0.0; 0.0 3.0 0.0; 0.0 0.0 3.0]]
+            m = FusedGradedMatrix([U1(0), U1(1)], blocks)
+            fm = f(m)
+            @test fm isa FusedGradedMatrix{Float64, Matrix{Float64}}
+            @test fm.blocks[U1(0)] ≈ f(blocks[1])
+            @test fm.blocks[U1(1)] ≈ f(blocks[2])
+        end
     end
 
     @testset "AbelianGradedArray" begin


### PR DESCRIPTION
## Summary

Fixes the matrix functions on `FusedGradedMatrix` (`sqrt`, `exp`, `log`, and the rest) throwing a `TypeError` on Julia 1.10. The per-block eltype unification spliced a runtime eltype into `convert(AbstractMatrix{T}, b)`, which older Julia's inference widened to an abstract `AbstractMatrix`, so the block dictionary lost its concrete type and reconstruction failed. Routing the eltype through a type-parameter function barrier keeps the `convert` target concrete, and a real `sqrt` still reconstructs concrete real blocks instead of being promoted to complex.