### PR TITLE
Define fermionparity for product sectors with a bosonic component

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/sectorproduct.jl
+++ b/src/sectorproduct.jl
@@ -47,6 +47,10 @@ end
 
 TKS.dim(s::SectorProduct) = prod(TKS.dim, arguments(s); init = 1)
 
+# Fermion parity of a product sector: the xor of its components' parities, mirroring
+# `TKS.fermionparity(::ProductSector)` (see `fermionparity` in `sectorrange.jl`).
+fermionparity(s::SectorProduct) = mapreduce(fermionparity, ⊻, arguments(s); init = false)
+
 # use map instead of broadcast to support both Tuple and NamedTuple
 TKS.dual(s::SectorProduct) = SectorProduct(map(TKS.dual, arguments(s)))
 

--- a/src/sectorrange.jl
+++ b/src/sectorrange.jl
@@ -102,8 +102,19 @@ flip(r1::SectorRange) = typeof(r1)(dual(r1.label), !isdual(r1))
 flip_dual(r::SectorRange) = isdual(r) ? flip(r) : r
 nondual(r::SectorRange) = isdual(r) ? dual(r) : r
 
-fermionparity(c::SectorRange) = TKS.fermionparity(c.label)
-twist(c::SectorRange) = TKS.twist(c.label)
+twist(c::SectorRange) = TKS.twist(label(c))
+
+# A total version of `TensorKitSectors.fermionparity`. TKS defines it only for
+# `FermionParity`, `NamedSector`, and `ProductSector`, and its `ProductSector` method
+# maps `fermionparity` over the components, so it errors on a bosonic component such as
+# the `U1Irrep` in `FermionNumber = U1Irrep ⊠ FermionParity`. We delegate to TKS where
+# it is defined, add the bosonic-irrep case a plain group irrep is bosonic, hence even
+# parity, and decompose product sectors over their components. The `SectorProduct`
+# method is defined alongside that type in `sectorproduct.jl`.
+fermionparity(c::SectorRange) = fermionparity(label(c))
+fermionparity(s::TKS.Sector) = TKS.fermionparity(s)
+fermionparity(::TKS.AbstractIrrep) = false
+fermionparity(s::TKS.ProductSector) = mapreduce(fermionparity, ⊻, s.sectors)
 
 Base.conj(r1::SectorRange) = dual(r1)
 

--- a/test/test_fermionic.jl
+++ b/test/test_fermionic.jl
@@ -1,15 +1,44 @@
 import GradedArrays
 using BlockArrays: Block, blocklengths, blocksize
 using BlockSparseArrays: eachblockstoredindex
-using GradedArrays: AbelianGradedArray, AbelianSectorArray, AbelianSectorDelta, SectorRange,
-    U1, data, dual, flip, gradedrange, isdual, sectoraxes, sectors
+using GradedArrays: AbelianGradedArray, AbelianSectorArray, AbelianSectorDelta,
+    SectorProduct, SectorRange, U1, data, dual, flip, gradedrange, isdual, sectoraxes,
+    sectors
 using Random: randn!
 using TensorAlgebra: contract, matricize, unmatricize
 using TensorKitSectors: TensorKitSectors as TKS
-using Test: @test, @testset
+using Test: @test, @test_throws, @testset
 
 const fP0 = SectorRange(TKS.FermionParity(false))  # even parity
 const fP1 = SectorRange(TKS.FermionParity(true))   # odd parity
+
+@testset "fermionparity / twist" begin
+    # `FermionNumber = U1Irrep ⊠ FermionParity` is a product sector with a bosonic
+    # component, on which `TKS.fermionparity` errors; decomposing over components with a
+    # bosonic-irrep fallback handles it.
+    for n in -2:2
+        c = SectorRange(TKS.FermionNumber(n))
+        @test GradedArrays.twist(c) == (isodd(n) ? -1 : 1)
+        @test GradedArrays.fermionparity(c) == isodd(n)
+    end
+
+    # The same holds for GradedArrays' own `SectorProduct`.
+    for n in -2:2
+        c = SectorRange(SectorProduct(TKS.U1Irrep(n), TKS.FermionParity(isodd(n))))
+        @test GradedArrays.fermionparity(c) == isodd(n)
+    end
+
+    # Plain bosonic group irreps have even fermion parity.
+    @test GradedArrays.fermionparity(SectorRange(TKS.U1Irrep(2))) == false
+    @test GradedArrays.fermionparity(U1(0)) == false
+
+    # `FermionParity` delegates to TensorKitSectors unchanged.
+    @test GradedArrays.fermionparity(fP0) == false
+    @test GradedArrays.fermionparity(fP1) == true
+
+    # A sector with no fermion parity (an anyon) has no method.
+    @test_throws MethodError GradedArrays.fermionparity(SectorRange(TKS.FibonacciAnyon(:τ)))
+end
 
 function randn_blockdiagonal(elt::Type, axs::Tuple)
     a = AbelianGradedArray{elt}(undef, axs...)


### PR DESCRIPTION
## Summary

Makes `GradedArrays.fermionparity` a total version of `TensorKitSectors.fermionparity` that works on product sectors with a bosonic component. TensorKitSectors defines `fermionparity` only for `FermionParity`, `NamedSector`, and `ProductSector`, and its `ProductSector` method maps `fermionparity` over the components, so it errors on a bosonic factor such as the `U1Irrep` in `FermionNumber = U1Irrep ⊠ FermionParity`. The definition here delegates to TensorKitSectors where it is defined, adds the bosonic-irrep case (a plain group irrep is bosonic, so even fermion parity), and decomposes both the TensorKitSectors `ProductSector` and GradedArrays' own `SectorProduct` over their components.