### PR TITLE
Drop eager permuteddims overloads now that broadcasting lowers through bipermutedimsopadd!

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.9.5"
+version = "0.9.6"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]
@@ -29,6 +29,10 @@ TypeParameterAccessors = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 SUNRepresentations = "1a50b95c-7aac-476d-a9ce-2bfc675fc617"
 
+[sources.TensorAlgebra]
+rev = "mf/permuteddims-unwrap"
+url = "https://github.com/ITensor/TensorAlgebra.jl"
+
 [extensions]
 GradedArraysNamedDimsArraysExt = "NamedDimsArrays"
 GradedArraysSUNRepresentationsExt = "SUNRepresentations"
@@ -45,12 +49,12 @@ HalfIntegers = "1.6"
 KroneckerArrays = "0.3.27"
 LinearAlgebra = "1.10"
 MatrixAlgebraKit = "0.6"
-NamedDimsArrays = "0.15"
+NamedDimsArrays = "0.15.9"
 Random = "1.10"
 SUNRepresentations = "0.3, 0.4"
 SparseArraysBase = "0.9"
 SplitApplyCombine = "1.2.3"
-TensorAlgebra = "0.9.5"
+TensorAlgebra = "0.9.6"
 TensorKitSectors = "0.3"
 TypeParameterAccessors = "0.4"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -29,10 +29,6 @@ TypeParameterAccessors = "7e5a90cf-f82e-492e-a09b-e3e26432c138"
 NamedDimsArrays = "60cbd0c0-df58-4cb7-918c-6f5607b73fde"
 SUNRepresentations = "1a50b95c-7aac-476d-a9ce-2bfc675fc617"
 
-[sources.TensorAlgebra]
-rev = "mf/permuteddims-unwrap"
-url = "https://github.com/ITensor/TensorAlgebra.jl"
-
 [extensions]
 GradedArraysNamedDimsArraysExt = "NamedDimsArrays"
 GradedArraysSUNRepresentationsExt = "SUNRepresentations"

--- a/src/abstractgradedarray.jl
+++ b/src/abstractgradedarray.jl
@@ -7,11 +7,6 @@ Concrete subtypes include [`AbelianGradedArray`](@ref) and [`FusedGradedMatrix`]
 abstract type AbstractGradedArray{T, N} <: AbstractArray{T, N} end
 const AbstractGradedMatrix{T} = AbstractGradedArray{T, 2}
 
-# Used by NamedDimsArrays broadcast alignment. Eager for simplicity for now,
-# pending the follow-ups on lazy permutations and the `FI.permuteddims`
-# interface itself.
-FI.permuteddims(a::AbstractGradedArray, perm) = permutedims(a, perm)
-
 function BlockSparseArrays.isblockdiagonal(A::AbstractGradedMatrix)
     for bI in eachblockstoredindex(A)
         row, col = Tuple(bI)

--- a/src/abstractsectorarray.jl
+++ b/src/abstractsectorarray.jl
@@ -9,11 +9,6 @@ Concrete subtypes:
 """
 abstract type AbstractSectorArray{T, N} <: AbstractArray{T, N} end
 
-# Used by NamedDimsArrays broadcast alignment. Eager for simplicity for now,
-# pending the follow-ups on lazy permutations and the `FI.permuteddims`
-# interface itself.
-FI.permuteddims(a::AbstractSectorArray, perm) = permutedims(a, perm)
-
 """
     data(sa::AbstractSectorArray)
 

--- a/src/abstractsectordelta.jl
+++ b/src/abstractsectordelta.jl
@@ -9,10 +9,5 @@ Concrete subtypes:
 """
 abstract type AbstractSectorDelta{T, N} <: AbstractArray{T, N} end
 
-# Used by NamedDimsArrays broadcast alignment. Eager for simplicity for now,
-# pending the follow-ups on lazy permutations and the `FI.permuteddims`
-# interface itself.
-FI.permuteddims(a::AbstractSectorDelta, perm) = permutedims(a, perm)
-
 Base.copy(A::AbstractSectorDelta) = A
 Base.size(A::AbstractSectorDelta) = length.(axes(A))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -22,14 +22,6 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 [sources.GradedArrays]
 path = ".."
 
-[sources.NamedDimsArrays]
-rev = "mf/drop-functionimplementations"
-url = "https://github.com/ITensor/NamedDimsArrays.jl"
-
-[sources.TensorAlgebra]
-rev = "mf/permuteddims-unwrap"
-url = "https://github.com/ITensor/TensorAlgebra.jl"
-
 [compat]
 Aqua = "0.8.11"
 BlockArrays = "1.6"
@@ -40,13 +32,13 @@ ITensorPkgSkeleton = "0.3.42"
 KroneckerArrays = "0.3"
 LinearAlgebra = "1.10"
 MatrixAlgebraKit = "0.6"
-NamedDimsArrays = "0.15"
+NamedDimsArrays = "0.15.9"
 Random = "1.10"
 SUNRepresentations = "0.3, 0.4"
 SafeTestsets = "0.1"
 SparseArraysBase = "0.9"
 Suppressor = "0.2.8"
-TensorAlgebra = "0.9.5"
+TensorAlgebra = "0.9.6"
 TensorKitSectors = "0.3"
 Test = "1.10"
 TestExtras = "0.3.1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -22,6 +22,14 @@ TestExtras = "5ed8adda-3752-4e41-b88a-e8b09835ee3a"
 [sources.GradedArrays]
 path = ".."
 
+[sources.NamedDimsArrays]
+rev = "mf/drop-functionimplementations"
+url = "https://github.com/ITensor/NamedDimsArrays.jl"
+
+[sources.TensorAlgebra]
+rev = "mf/permuteddims-unwrap"
+url = "https://github.com/ITensor/TensorAlgebra.jl"
+
 [compat]
 Aqua = "0.8.11"
 BlockArrays = "1.6"


### PR DESCRIPTION
## Summary

Removes the eager `FunctionImplementations.permuteddims` overloads on `AbstractGradedArray`, `AbstractSectorArray`, and `AbstractSectorDelta`. These existed only to align graded operands during `NamedDimsArrays` broadcasting by materializing a permuted copy. `NamedDimsArrays` now aligns lazily and lowers linear broadcasts through `bipermutedimsopadd!` (https://github.com/ITensor/TensorAlgebra.jl/pull/178, https://github.com/ITensor/NamedDimsArrays.jl/pull/232), so a permuted graded operand reaches the block-wise `bipermutedimsopadd!` without the eager copy.

Bumps the `TensorAlgebra` and `NamedDimsArrays` compat floors to the versions that introduce that path.