### PR TITLE
Add block-aware ones / fill and rand / randn constructors for graded axes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GradedArrays"
 uuid = "bc96ca6e-b7c8-4bb6-888e-c93f838762c2"
-version = "0.9.7"
+version = "0.9.8"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/src/abeliangradedarray.jl
+++ b/src/abeliangradedarray.jl
@@ -395,6 +395,65 @@ function Base.randn(
     return Random.randn!(rng, AbelianGradedArray{T}(undef, ax))
 end
 
+# Shorthand shims forwarding to the canonical `(rng, T, tuple)` forms above. Base's
+# `rand`/`randn` defaulting chain hardcodes `Integer` / `Dims` argument shapes, so the
+# non-canonical forms (`rand(i, j)`, `rand(T, i, j)`, `rand((i, j))`, ...) never reach the
+# graded constructor on their own. A leading `GradedOneTo` keeps these from shadowing the
+# zero-argument `rand()` / `randn()`.
+function Base.rand(ax::GradedOneTo, axs::GradedOneTo...)
+    return rand(Random.default_rng(), Float64, (ax, axs...))
+end
+function Base.rand(::Type{T}, ax::GradedOneTo, axs::GradedOneTo...) where {T}
+    return rand(Random.default_rng(), T, (ax, axs...))
+end
+function Base.rand(rng::AbstractRNG, ax::GradedOneTo, axs::GradedOneTo...)
+    return rand(rng, Float64, (ax, axs...))
+end
+function Base.rand(
+        rng::AbstractRNG,
+        ::Type{T},
+        ax::GradedOneTo,
+        axs::GradedOneTo...
+    ) where {T}
+    return rand(rng, T, (ax, axs...))
+end
+function Base.rand(ax::Tuple{GradedOneTo, Vararg{GradedOneTo}})
+    return rand(Random.default_rng(), Float64, ax)
+end
+function Base.rand(::Type{T}, ax::Tuple{GradedOneTo, Vararg{GradedOneTo}}) where {T}
+    return rand(Random.default_rng(), T, ax)
+end
+function Base.rand(rng::AbstractRNG, ax::Tuple{GradedOneTo, Vararg{GradedOneTo}})
+    return rand(rng, Float64, ax)
+end
+
+function Base.randn(ax::GradedOneTo, axs::GradedOneTo...)
+    return randn(Random.default_rng(), Float64, (ax, axs...))
+end
+function Base.randn(::Type{T}, ax::GradedOneTo, axs::GradedOneTo...) where {T}
+    return randn(Random.default_rng(), T, (ax, axs...))
+end
+function Base.randn(rng::AbstractRNG, ax::GradedOneTo, axs::GradedOneTo...)
+    return randn(rng, Float64, (ax, axs...))
+end
+function Base.randn(
+        rng::AbstractRNG,
+        ::Type{T},
+        ax::GradedOneTo,
+        axs::GradedOneTo...
+    ) where {T}
+    return randn(rng, T, (ax, axs...))
+end
+function Base.randn(ax::Tuple{GradedOneTo, Vararg{GradedOneTo}})
+    return randn(Random.default_rng(), Float64, ax)
+end
+function Base.randn(::Type{T}, ax::Tuple{GradedOneTo, Vararg{GradedOneTo}}) where {T}
+    return randn(Random.default_rng(), T, ax)
+end
+function Base.randn(rng::AbstractRNG, ax::Tuple{GradedOneTo, Vararg{GradedOneTo}})
+    return randn(rng, Float64, ax)
+end
+
 # Block-aware diagonal check: block-diagonal (no off-diagonal stored blocks), and each
 # stored diagonal block is itself diagonal. Bypasses the generic scalar-indexing path.
 function LinearAlgebra.isdiag(A::AbelianGradedMatrix)
@@ -557,21 +616,66 @@ end
 #  zeros / rand  (allowedblocks is defined in fusion.jl)
 # ---------------------------------------------------------------------------
 
+# A leading mandatory `GradedOneTo` on every vararg form (and `Tuple{GradedOneTo,
+# Vararg{GradedOneTo}}` on every tuple form) keeps these from matching the zero-argument
+# calls (`zeros()`, `ones()`, `fill(v)`, `zeros(T, ())`), which would pirate Base for calls
+# that involve no GradedArrays-owned type.
+
 """
-    zeros(T, axs::GradedOneTo...)
+    zeros(T, ax1::GradedOneTo, axs::GradedOneTo...)
 
 Create an `AbelianGradedArray{T}` with all allowed (zero-flux) blocks filled with zeros.
 """
-function Base.zeros(::Type{T}, axs::GradedOneTo{S}...) where {T, S <: SectorRange}
-    return FI.zero!(AbelianGradedArray{T}(undef, axs...))
+function Base.zeros(
+        ::Type{T}, ax1::GradedOneTo{S}, axs::GradedOneTo{S}...
+    ) where {T, S <: SectorRange}
+    return FI.zero!(AbelianGradedArray{T}(undef, ax1, axs...))
 end
 
-function Base.zeros(axs::GradedOneTo...)
+function Base.zeros(ax1::GradedOneTo, axs::GradedOneTo...)
+    return zeros(Float64, ax1, axs...)
+end
+
+function Base.zeros(::Type{T}, axs::Tuple{GradedOneTo, Vararg{GradedOneTo}}) where {T}
+    return zeros(T, axs...)
+end
+
+function Base.zeros(axs::Tuple{GradedOneTo, Vararg{GradedOneTo}})
     return zeros(Float64, axs...)
 end
 
-function Base.zeros(
-        ::Type{T}, axs::NTuple{N, GradedOneTo{S}}
-    ) where {T, N, S <: SectorRange}
-    return zeros(T, axs...)
+"""
+    ones(T, ax1::GradedOneTo, axs::GradedOneTo...)
+
+Create an `AbelianGradedArray{T}` with all allowed (zero-flux) blocks filled with ones.
+"""
+function Base.ones(
+        ::Type{T}, ax1::GradedOneTo{S}, axs::GradedOneTo{S}...
+    ) where {T, S <: SectorRange}
+    return fill!(AbelianGradedArray{T}(undef, ax1, axs...), one(T))
+end
+
+function Base.ones(ax1::GradedOneTo, axs::GradedOneTo...)
+    return ones(Float64, ax1, axs...)
+end
+
+function Base.ones(::Type{T}, axs::Tuple{GradedOneTo, Vararg{GradedOneTo}}) where {T}
+    return ones(T, axs...)
+end
+
+function Base.ones(axs::Tuple{GradedOneTo, Vararg{GradedOneTo}})
+    return ones(Float64, axs...)
+end
+
+"""
+    fill(v, ax1::GradedOneTo, axs::GradedOneTo...)
+
+Create an `AbelianGradedArray{typeof(v)}` with all allowed (zero-flux) blocks filled with `v`.
+"""
+function Base.fill(v, ax1::GradedOneTo{S}, axs::GradedOneTo{S}...) where {S <: SectorRange}
+    return fill!(AbelianGradedArray{typeof(v)}(undef, ax1, axs...), v)
+end
+
+function Base.fill(v, axs::Tuple{GradedOneTo, Vararg{GradedOneTo}})
+    return fill(v, axs...)
 end

--- a/test/test_abelianarray.jl
+++ b/test/test_abelianarray.jl
@@ -408,6 +408,60 @@ end
     @test !iszero(u)
 end
 
+@testset "Block-aware ones/fill and rand/randn shorthands" begin
+    g1 = gradedrange([U1(0) => 2, U1(1) => 3])
+    g2 = gradedrange([U1(0) => 1, U1(-1) => 2])
+
+    # `ones`/`fill` allocate the allowed sectors and fill them with the value, exactly
+    # like `fill!(zeros(ax...), v)`. Vararg and tuple forms, default and explicit eltype.
+    reference1(v) = fill!(zeros(typeof(v), g1, g2), v)
+    @testset "ones" begin
+        for o in
+            (ones(g1, g2), ones(Float64, g1, g2), ones((g1, g2)), ones(Float64, (g1, g2)))
+            @test o isa AbelianGradedArray{Float64, 2}
+            @test axes(o) == (g1, g2)
+            @test Array(o) == Array(reference1(1.0))
+        end
+        @test ones(ComplexF64, g1, g2) isa AbelianGradedArray{ComplexF64, 2}
+    end
+    @testset "fill" begin
+        for a in (fill(2.5, g1, g2), fill(2.5, (g1, g2)))
+            @test a isa AbelianGradedArray{Float64, 2}
+            @test axes(a) == (g1, g2)
+            @test Array(a) == Array(reference1(2.5))
+        end
+        @test fill(1.0im, g1, g2) isa AbelianGradedArray{ComplexF64, 2}
+    end
+
+    # rand/randn shorthands forward to the canonical `(rng, T, tuple)` form, so a seeded
+    # shorthand matches a seeded canonical call. All non-canonical arg shapes are covered.
+    @testset "$f shorthands" for f in (rand, randn)
+        @test f(g1, g2) isa AbelianGradedArray{Float64, 2}
+        @test f(ComplexF64, g1, g2) isa AbelianGradedArray{ComplexF64, 2}
+        @test f((g1, g2)) isa AbelianGradedArray{Float64, 2}
+        @test f(ComplexF64, (g1, g2)) isa AbelianGradedArray{ComplexF64, 2}
+        @test f(Random.Xoshiro(1), g1, g2) isa AbelianGradedArray{Float64, 2}
+        @test f(Random.Xoshiro(1), (g1, g2)) isa AbelianGradedArray{Float64, 2}
+        # Seeded shorthand == seeded canonical, for every shape that fills in defaults.
+        @test Array(f(Random.Xoshiro(1), Float64, g1, g2)) ==
+            Array(f(Random.Xoshiro(1), Float64, (g1, g2)))
+        @test Array(f(Random.Xoshiro(1), g1, g2)) ==
+            Array(f(Random.Xoshiro(1), Float64, (g1, g2)))
+    end
+
+    # Regression: the leading mandatory `GradedOneTo` keeps these from pirating the
+    # zero-argument / no-graded Base calls.
+    @testset "no piracy of zero-argument Base calls" begin
+        @test zeros() isa Array{Float64, 0}
+        @test ones() isa Array{Float64, 0}
+        @test fill(1.0) isa Array{Float64, 0}
+        @test rand() isa Float64
+        @test randn() isa Float64
+        @test zeros(2, 3) isa Matrix{Float64}
+        @test ones(Float64, 2, 3) isa Matrix{Float64}
+    end
+end
+
 @testset "conj flips axis duality" begin
     g = gradedrange([U1(0) => 2, U1(1) => 3])
     a = AbelianGradedArray{ComplexF64}(undef, g, dual(g))


### PR DESCRIPTION
## Summary

Adds the block-aware array-creation constructors that were missing for `GradedOneTo` axes, matching the existing `zeros`. `ones(axs...)` and `fill(v, axs...)` allocate an `AbelianGradedArray` over the symmetry-allowed sectors and fill those sectors with `one(T)` / `v` (the same block-aware path as `fill!(zeros(axs...), v)`), instead of falling through to a generic `similar` that errors. The `rand` / `randn` shorthands (`rand(i, j)`, `rand(T, i, j)`, `rand(rng, i, j)`, the tuple forms, ...) now forward to the canonical `rand(rng, T, (axs...,))` form instead of `MethodError`ing.

Every form takes a leading mandatory `GradedOneTo` (and the tuple forms are `Tuple{GradedOneTo, Vararg{GradedOneTo}}`), so none matches a zero-argument or non-graded call like `ones()` / `fill(v)` / `zeros(2, 2)`, which would otherwise pirate Base. The existing `zeros` had that gap and is tightened the same way.